### PR TITLE
ci: run build on all lts node versions supported

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -10,7 +10,7 @@ jobs:
   Build-And-Test:
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -10,7 +10,7 @@ jobs:
   Build-And-Test:
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [16.x, 18.x, 20.x]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

Making sure we build and test on all node lts versions above our min supported. (which is dictated by open feature)  

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing
- [ ] Relevant documentation updated
- [ ] linter/style run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app
