### PR TITLE
build: make example apps work with bundled entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ If you intend to change the public API you need to run the bundle command locall
 yarn bundle
 ```
 
+## Example apps
+
+This repo contains a few example apps (under examples/) to display and test the functionality. These apps depend on the bundled output of the main packages, so you will need to run `yarn bundle` before starting any of the apps.
+
 ## Code of Conduct
 
 This project adheres to the [Open Source Code of

--- a/examples/nodeCJS/src/index.js
+++ b/examples/nodeCJS/src/index.js
@@ -1,21 +1,26 @@
-const { createConfidenceServerProvider } = require('@spotify-confidence/openfeature-server-provider');
 const { OpenFeature } = require('@openfeature/server-sdk');
 
-const provider = createConfidenceServerProvider({
-  clientSecret: 'RxDVTrXvc6op1XxiQ4OaR31dKbJ39aYV',
-  region: 'eu',
-  fetchImplementation: fetch,
-  timeout: 1000,
-});
+main();
 
-OpenFeature.setProvider(provider);
+async function main() {
+  const { createConfidenceServerProvider } = await import('@spotify-confidence/openfeature-server-provider');
 
-const client = OpenFeature.getClient();
-
-client
-  .getBooleanValue('web-sdk-e2e-flag.bool', false, {
-    targetingKey: `user-${Math.random()}`,
-  })
-  .then(result => {
-    console.log('result:', result);
+  const provider = createConfidenceServerProvider({
+    clientSecret: 'RxDVTrXvc6op1XxiQ4OaR31dKbJ39aYV',
+    region: 'eu',
+    fetchImplementation: fetch,
+    timeout: 1000,
   });
+
+  OpenFeature.setProvider(provider);
+
+  const client = OpenFeature.getClient();
+
+  client
+    .getBooleanValue('web-sdk-e2e-flag.bool', false, {
+      targetingKey: `user-${Math.random()}`,
+    })
+    .then(result => {
+      console.log('result:', result);
+    });
+}

--- a/packages/client-http/package.json
+++ b/packages/client-http/package.json
@@ -2,7 +2,6 @@
   "name": "@spotify-confidence/client-http",
   "license": "Apache-2.0",
   "version": "0.1.6",
-  "module": "build/esm/index.js",
   "types": "build/types/index.d.ts",
   "files": [
     "dist/index.*"
@@ -18,11 +17,12 @@
   "publishConfig": {
     "access": "public",
     "types": "dist/index.d.ts",
-    "module": "dist/index.js"
+    "main": "dist/index.js"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "*",
     "rollup": "*"
   },
-  "type": "module"
+  "type": "module",
+  "main": "dist/index.js"
 }

--- a/packages/openfeature-server-provider/package.json
+++ b/packages/openfeature-server-provider/package.json
@@ -3,7 +3,6 @@
   "license": "Apache-2.0",
   "version": "0.2.3",
   "type": "module",
-  "module": "build/esm/index.js",
   "types": "build/types/index.d.ts",
   "devDependencies": {
     "@microsoft/api-extractor": "*",
@@ -18,7 +17,7 @@
   "publishConfig": {
     "access": "public",
     "types": "dist/index.d.ts",
-    "module": "dist/index.js"
+    "main": "dist/index.js"
   },
   "scripts": {
     "build": "tsc",
@@ -26,5 +25,6 @@
   },
   "files": [
     "dist/index.*"
-  ]
+  ],
+  "main": "dist/index.js"
 }

--- a/packages/openfeature-web-provider/package.json
+++ b/packages/openfeature-web-provider/package.json
@@ -3,7 +3,6 @@
   "license": "Apache-2.0",
   "version": "0.2.3",
   "type": "module",
-  "module": "build/esm/index.js",
   "types": "build/types/index.d.ts",
   "dependencies": {
     "fast-deep-equal": "^3.1.3"
@@ -21,7 +20,7 @@
   "publishConfig": {
     "access": "public",
     "types": "dist/index.d.ts",
-    "module": "dist/index.js"
+    "main": "dist/index.js"
   },
   "scripts": {
     "build": "tsc",
@@ -29,5 +28,6 @@
   },
   "files": [
     "dist/index.*"
-  ]
+  ],
+  "main": "dist/index.js"
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -2,7 +2,6 @@
   "name": "@spotify-confidence/sdk",
   "license": "Apache-2.0",
   "version": "0.0.5",
-  "module": "build/esm/index.js",
   "types": "build/types/index.d.ts",
   "engineStrict": true,
   "engines": {
@@ -15,7 +14,7 @@
   "publishConfig": {
     "access": "public",
     "types": "dist/index.d.ts",
-    "module": "dist/index.js"
+    "main": "dist/index.js"
   },
   "dependencies": {
     "@spotify-confidence/client-http": "0.1.6",
@@ -28,5 +27,6 @@
   "devDependencies": {
     "@microsoft/api-extractor": "*",
     "rollup": "*"
-  }
+  },
+  "main": "dist/index.js"
 }

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -15,7 +15,8 @@ module.exports = defineConfig({
         continue;
       }
       workspace.set('type', 'module');
-      workspace.set('module', 'build/esm/index.js');
+      workspace.set('main', 'dist/index.js');
+      workspace.unset('module');
       workspace.set('types', 'build/types/index.d.ts');
       workspace.set('files', ['dist/index.*']);
       workspace.set('scripts.build', 'tsc');
@@ -23,7 +24,7 @@ module.exports = defineConfig({
       workspace.set('publishConfig', {
         access: 'public',
         types: 'dist/index.d.ts',
-        module: 'dist/index.js',
+        main: 'dist/index.js',
       });
       workspace.set('devDependencies.@microsoft/api-extractor', '*');
       workspace.set('devDependencies.rollup', '*');


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

This makes our example apps use the bundled entry points of our packages.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing
- [ ] Relevant documentation updated
- [ ] linter/style run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app
