### PR TITLE
fix: widen flag return types

### DIFF
--- a/api/sdk.api.md
+++ b/api/sdk.api.md
@@ -25,11 +25,11 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     // (undocumented)
     get environment(): string;
     // (undocumented)
-    evaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<T>;
+    evaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<Value.Widen<T>>;
     // (undocumented)
     getContext(): Context;
     // (undocumented)
-    getFlag<T extends Value>(path: string, defaultValue: T): Promise<T>;
+    getFlag<T extends Value>(path: string, defaultValue: T): Promise<Value.Widen<T>>;
     // (undocumented)
     setContext(context: Context): void;
     // (undocumented)
@@ -158,9 +158,9 @@ export interface FlagResolver extends Contextual<FlagResolver> {
         timeout: number;
     };
     // (undocumented)
-    evaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<T>;
+    evaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<Value.Widen<T>>;
     // (undocumented)
-    getFlag<T extends Value>(path: string, defaultValue: T): Promise<T>;
+    getFlag<T extends Value>(path: string, defaultValue: T): Promise<Value.Widen<T>>;
     // (undocumented)
     subscribe(onStateChange?: StateObserver): () => void;
 }
@@ -223,6 +223,8 @@ export namespace Value {
     };
     // (undocumented)
     export type TypeName = 'number' | 'string' | 'boolean' | 'Struct' | 'List' | 'undefined';
+    // (undocumented)
+    export type Widen<T extends Value> = T extends number ? number : T extends string ? string : T extends boolean ? boolean : T;
 }
 
 // @public (undocumented)

--- a/packages/openfeature-server-provider/src/ConfidenceServerProvider.ts
+++ b/packages/openfeature-server-provider/src/ConfidenceServerProvider.ts
@@ -9,7 +9,7 @@ import {
   ResolutionDetails,
 } from '@openfeature/server-sdk';
 
-import { Context, FlagResolver, Value } from '@spotify-confidence/sdk';
+import { Context, FlagEvaluation, FlagResolver, Value } from '@spotify-confidence/sdk';
 
 type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 
@@ -29,7 +29,9 @@ export class ConfidenceServerProvider implements Provider {
     defaultValue: T,
     context: EvaluationContext,
   ): Promise<ResolutionDetails<T>> {
-    const evaluation = await this.confidence.withContext(convertContext(context)).evaluateFlag(flagKey, defaultValue);
+    const evaluation = (await this.confidence
+      .withContext(convertContext(context))
+      .evaluateFlag(flagKey, defaultValue)) as FlagEvaluation.Resolved<T>;
 
     if (evaluation.reason === 'ERROR') {
       const { errorCode, ...rest } = evaluation;

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
@@ -11,7 +11,7 @@ import {
 } from '@openfeature/web-sdk';
 import equal from 'fast-deep-equal';
 
-import { Value, Context, FlagResolver } from '@spotify-confidence/sdk';
+import { Value, Context, FlagResolver, FlagEvaluation } from '@spotify-confidence/sdk';
 
 type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 
@@ -77,7 +77,7 @@ export class ConfidenceWebProvider implements Provider {
   }
 
   private evaluateFlag<T extends Value>(flagKey: string, defaultValue: T): ResolutionDetails<T> {
-    const evaluation = this.confidence.evaluateFlag(flagKey, defaultValue);
+    const evaluation = this.confidence.evaluateFlag(flagKey, defaultValue) as FlagEvaluation<T>;
     if (evaluation.reason === 'ERROR') {
       const { errorCode, ...rest } = evaluation;
       return {

--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -210,7 +210,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     }).finally(close!);
   }
 
-  evaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<T> {
+  evaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<Value.Widen<T>> {
     let evaluation: FlagEvaluation<T>;
     if (!this.currentFlags) {
       evaluation = {
@@ -226,12 +226,12 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     if (!this.currentFlags || !Value.equal(this.currentFlags.context, this.getContext())) {
       const then: PromiseLike<FlagEvaluation.Resolved<T>>['then'] = (onfulfilled?, onrejected?) =>
         this.evaluateFlagAsync(path, defaultValue).then(onfulfilled, onrejected);
-      return Object.assign(evaluation, { then });
+      return Object.assign(evaluation, { then }) as FlagEvaluation<Value.Widen<T>>;
     }
-    return evaluation;
+    return evaluation as FlagEvaluation<Value.Widen<T>>;
   }
 
-  async getFlag<T extends Value>(path: string, defaultValue: T): Promise<T> {
+  async getFlag<T extends Value>(path: string, defaultValue: T): Promise<Value.Widen<T>> {
     return (await this.evaluateFlag(path, defaultValue)).value;
   }
 

--- a/packages/sdk/src/Value.ts
+++ b/packages/sdk/src/Value.ts
@@ -12,6 +12,14 @@ export namespace Value {
   };
   export type List = ReadonlyArray<number> | ReadonlyArray<string> | ReadonlyArray<boolean>;
 
+  export type Widen<T extends Value> = T extends number
+    ? number
+    : T extends string
+      ? string
+      : T extends boolean
+        ? boolean
+        : T;
+
   export function assertValue(value: unknown): asserts value is Value {
     switch (typeof value) {
       case 'bigint':

--- a/packages/sdk/src/Value.ts
+++ b/packages/sdk/src/Value.ts
@@ -15,10 +15,10 @@ export namespace Value {
   export type Widen<T extends Value> = T extends number
     ? number
     : T extends string
-      ? string
-      : T extends boolean
-        ? boolean
-        : T;
+    ? string
+    : T extends boolean
+    ? boolean
+    : T;
 
   export function assertValue(value: unknown): asserts value is Value {
     switch (typeof value) {

--- a/packages/sdk/src/flags.ts
+++ b/packages/sdk/src/flags.ts
@@ -40,6 +40,7 @@ export interface FlagResolver extends Contextual<FlagResolver> {
 
   subscribe(onStateChange?: StateObserver): () => void;
 
-  evaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<T>;
-  getFlag<T extends Value>(path: string, defaultValue: T): Promise<T>;
+  evaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<Value.Widen<T>>;
+
+  getFlag<T extends Value>(path: string, defaultValue: T): Promise<Value.Widen<T>>;
 }


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

Right now we have an issue that flag value types are too aggressively "narrowed" by TS. For instance:
```
const value = await confidence.getFlag('ff', 3);
```
Right now TS will infer the type of value to be `3` withe the desired type being `number`. This PR fixes that. Ideally we should have type tests for this sort of thing. But that is saved for another day.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing
- [ ] Relevant documentation updated
- [ ] linter/style run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app
