### PR TITLE
fix: excessive promises created by PendingResolution

### DIFF
--- a/packages/sdk/src/AccessiblePromise.test.ts
+++ b/packages/sdk/src/AccessiblePromise.test.ts
@@ -17,6 +17,14 @@ describe('AccessiblePromise', () => {
       expect(other.state).toBe('RESOLVED');
       expect(other.or(0)).toBe(238);
     });
+
+    it('rejects if then handler throws', () => {
+      const other = resolved.then<number>(() => {
+        throw 'error';
+      });
+      expect(other.state).toBe('REJECTED');
+      expect(() => other.or(0)).toThrow('error');
+    });
   });
 
   describe('pending', () => {

--- a/packages/sdk/src/AccessiblePromise.ts
+++ b/packages/sdk/src/AccessiblePromise.ts
@@ -25,6 +25,11 @@ export class AccessiblePromise<T> {
       this.#state = rejected ? 'REJECTED' : 'RESOLVED';
     }
   }
+
+  protected chain<T>(value: any, rejected?: boolean): AccessiblePromise<T> {
+    return new AccessiblePromise(value, rejected);
+  }
+
   get state(): 'PENDING' | 'RESOLVED' | 'REJECTED' {
     return this.#state;
   }
@@ -60,7 +65,7 @@ export class AccessiblePromise<T> {
         }
         break;
     }
-    return new AccessiblePromise(value, rejected);
+    return this.chain(value, rejected);
   }
 
   catch<TResult = never>(

--- a/packages/sdk/src/FlagResolverClient.ts
+++ b/packages/sdk/src/FlagResolverClient.ts
@@ -18,10 +18,14 @@ export class PendingResolution<T = FlagResolution> extends AccessiblePromise<T> 
   #context: Context;
   #controller: AbortController;
 
-  protected constructor(promise: PromiseLike<T>, context: Context, controller: AbortController) {
-    super(promise);
+  protected constructor(promise: PromiseLike<T>, context: Context, controller: AbortController, rejected?: boolean) {
+    super(promise, rejected);
     this.#context = context;
     this.#controller = controller;
+  }
+
+  protected chain<T>(value: any, rejected?: boolean | undefined): PendingResolution<T> {
+    return new PendingResolution(value, this.#context, this.#controller, rejected);
   }
 
   get context(): Context {
@@ -36,17 +40,17 @@ export class PendingResolution<T = FlagResolution> extends AccessiblePromise<T> 
     onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null | undefined,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined,
   ): PendingResolution<TResult1 | TResult2> {
-    return new PendingResolution(super.then(onfulfilled, onrejected), this.#context, this.#controller);
+    return super.then(onfulfilled, onrejected) as PendingResolution<TResult1 | TResult2>;
   }
 
   catch<TResult = never>(
     onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null | undefined,
   ): PendingResolution<T | TResult> {
-    return new PendingResolution(super.catch(onrejected), this.#context, this.#controller);
+    return super.catch(onrejected) as PendingResolution<T | TResult>;
   }
 
   finally(onfinally?: (() => void) | null | undefined): PendingResolution<T> {
-    return new PendingResolution(super.finally(onfinally), this.#context, this.#controller);
+    return super.finally(onfinally) as PendingResolution<T>;
   }
 
   static create(


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

Fixes a bug in PendingResolution that caused an avalanche of AccessiblePromises being created for each then, catch of finally call.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing
- [ ] Relevant documentation updated
- [ ] linter/style run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app
