### PR TITLE
fix: cache timeouts

### DIFF
--- a/api/react.api.md
+++ b/api/react.api.md
@@ -13,7 +13,6 @@ import { FC } from 'react';
 import { FlagEvaluation } from '@spotify-confidence/sdk';
 import { FlagResolver } from '@spotify-confidence/sdk';
 import { PropsWithChildren } from 'react';
-import { State } from '@spotify-confidence/sdk';
 import { StateObserver } from '@spotify-confidence/sdk';
 import { Trackable } from '@spotify-confidence/sdk';
 import { Value } from '@spotify-confidence/sdk';
@@ -43,6 +42,8 @@ export class ConfidenceReact implements EventSender, Trackable, FlagResolver {
     // (undocumented)
     get config(): Configuration;
     // @internal (undocumented)
+    get contextState(): string;
+    // @internal (undocumented)
     readonly delegate: Confidence;
     // (undocumented)
     evaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<Value.Widen<T>>;
@@ -52,8 +53,6 @@ export class ConfidenceReact implements EventSender, Trackable, FlagResolver {
     getFlag<T extends Value>(path: string, defaultValue: T): Promise<Value.Widen<T>>;
     // (undocumented)
     setContext(context: Context): void;
-    // @internal (undocumented)
-    get state(): State;
     // (undocumented)
     subscribe(onStateChange?: StateObserver | undefined): () => void;
     // (undocumented)

--- a/api/react.api.md
+++ b/api/react.api.md
@@ -87,7 +87,7 @@ export function useFlag<T extends Value>(path: string, defaultValue: T, confiden
 // Warning: (ae-missing-release-tag) "useWithContext" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export function useWithContext(context: Context, confidence?: ConfidenceReact): ConfidenceReact;
+export function useWithContext(context: Context, parent?: ConfidenceReact): ConfidenceReact;
 
 // (No @packageDocumentation comment for this package)
 

--- a/api/sdk.api.md
+++ b/api/sdk.api.md
@@ -154,9 +154,11 @@ export interface EventSender extends Contextual<EventSender> {
 // @public (undocumented)
 export namespace FlagEvaluation {
     // (undocumented)
+    export type ErrorCode = 'FLAG_NOT_FOUND' | 'TYPE_MISMATCH' | 'NOT_READY' | 'TIMEOUT' | 'GENERAL';
+    // (undocumented)
     export interface Failed<T> {
         // (undocumented)
-        readonly errorCode: 'FLAG_NOT_FOUND' | 'TYPE_MISMATCH' | 'NOT_READY' | 'GENERAL';
+        readonly errorCode: ErrorCode;
         // (undocumented)
         readonly errorMessage: string;
         // (undocumented)
@@ -193,10 +195,6 @@ export type FlagEvaluation<T> = FlagEvaluation.Resolved<T> | FlagEvaluation.Stal
 //
 // @public (undocumented)
 export interface FlagResolver extends Contextual<FlagResolver> {
-    // (undocumented)
-    readonly config: {
-        timeout: number;
-    };
     // (undocumented)
     evaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<Value.Widen<T>>;
     // (undocumented)

--- a/examples/react18/src/App.tsx
+++ b/examples/react18/src/App.tsx
@@ -20,15 +20,13 @@ const handleFailRequestsOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 const confidence = Confidence.create({
   clientSecret: 'RxDVTrXvc6op1XxiQ4OaR31dKbJ39aYV',
   environment: 'client',
-  timeout: 5000,
+  timeout: 3000,
   logger: console,
   fetchImplementation: (req: Request) => {
     console.log('request', req.url);
     return state.failRequests ? Promise.resolve(new Response(null, { status: 500 })) : fetch(req);
   },
 });
-
-// confidence.track(pageViews());
 
 function App() {
   return (
@@ -69,7 +67,7 @@ function Outer() {
 
 function Inner() {
   const [count, setCount] = React.useState(0);
-  console.log('Inner render', count, performance.now());
+  console.log('Inner render', count);
 
   return (
     <fieldset>

--- a/examples/react18/src/App.tsx
+++ b/examples/react18/src/App.tsx
@@ -1,32 +1,109 @@
-import React from 'react';
+import React, { Suspense, useCallback } from 'react';
 import TestComponent from './TestComponent';
 import { Confidence, pageViews } from '@spotify-confidence/sdk';
-import { ConfidenceProvider } from '@spotify-confidence/react';
+import { ConfidenceProvider, ConfidenceReact, useConfidence } from '@spotify-confidence/react';
+import { Contextual } from '@spotify-confidence/sdk';
+
+const state = {
+  get failRequests(): boolean {
+    return document.location.hash === '#fail';
+  },
+  set failRequests(value: boolean) {
+    document.location.hash = value ? '#fail' : '';
+  },
+};
+
+const handleFailRequestsOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  state.failRequests = e.target.checked;
+};
 
 const confidence = Confidence.create({
   clientSecret: 'RxDVTrXvc6op1XxiQ4OaR31dKbJ39aYV',
-  region: 'eu',
   environment: 'client',
-  timeout: 1000,
+  timeout: 5000,
   logger: console,
+  fetchImplementation: (req: Request) => {
+    console.log('request', req.url);
+    return state.failRequests ? Promise.resolve(new Response(null, { status: 500 })) : fetch(req);
+  },
 });
 
-confidence.track(pageViews());
+// confidence.track(pageViews());
 
 function App() {
   return (
     <ConfidenceProvider confidence={confidence}>
       <h1>React 18 Example</h1>
-      <div style={{ height: 2000 }}>
-        <React.Suspense fallback={<p>Loading... </p>}>
-          <ConfidenceProvider.WithContext context={{ targeting_key: 'user-a' }}>
-            <TestComponent />
-          </ConfidenceProvider.WithContext>
-        </React.Suspense>
-      </div>
-      <p>bottom</p>
+      <label>
+        <input type="checkbox" defaultChecked={state.failRequests} onChange={handleFailRequestsOnChange} /> Fail
+        requests.
+      </label>
+
+      <Suspense fallback="App loading...">
+        <Outer />
+      </Suspense>
     </ConfidenceProvider>
   );
 }
 
 export default App;
+
+function Outer() {
+  console.log('Outer render', performance.now());
+  return (
+    <fieldset>
+      <legend>Outer</legend>
+      <div>
+        <ContextControl confidence={useConfidence()} />
+      </div>
+      <div>
+        <React.Suspense fallback="Outer loading...">
+          <ConfidenceProvider.WithContext context={{ name: 'inner' }}>
+            <Inner />
+          </ConfidenceProvider.WithContext>
+        </React.Suspense>
+      </div>
+    </fieldset>
+  );
+}
+
+function Inner() {
+  const [count, setCount] = React.useState(0);
+  console.log('Inner render', count, performance.now());
+
+  return (
+    <fieldset>
+      <legend>Inner</legend>
+      <ContextControl confidence={useConfidence()} />
+      <fieldset>
+        <legend>Flags</legend>
+        <pre>{JSON.stringify(useConfidence().useEvaluateFlag('web-sdk-e2e-flag.str', 'default'), null, '  ')}</pre>
+      </fieldset>
+      <button onClick={() => setCount(value => value + 1)}>Rerender</button>
+    </fieldset>
+  );
+}
+function ContextControl({ confidence }: { confidence: Contextual<any> }) {
+  const name = String(confidence.getContext().name ?? '');
+  const toggleTargetingKey = useCallback(() => {
+    let { targeting_key } = confidence.getContext();
+    if (targeting_key === 'user-a') {
+      targeting_key = 'user-b';
+    } else {
+      targeting_key = 'user-a';
+    }
+    confidence.setContext({ targeting_key });
+  }, [confidence]);
+
+  return (
+    <fieldset>
+      <legend>Context {name}</legend>
+      <pre>{JSON.stringify(confidence.getContext())}</pre>
+      <button onClick={() => confidence.setContext({ targeting_key: Math.floor(2e6 * Math.random()).toString(16) })}>
+        Randomize
+      </button>
+      <button onClick={toggleTargetingKey}>Toggle</button>
+      <button onClick={() => confidence.clearContext()}>Clear</button>
+    </fieldset>
+  );
+}

--- a/examples/react18/src/index.tsx
+++ b/examples/react18/src/index.tsx
@@ -4,9 +4,8 @@ import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 
-// root.render(
-//   <React.StrictMode>
-//     <App />
-//   </React.StrictMode>,
-// );
-root.render(<App />);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/examples/react18/src/index.tsx
+++ b/examples/react18/src/index.tsx
@@ -4,8 +4,9 @@ import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+// root.render(
+//   <React.StrictMode>
+//     <App />
+//   </React.StrictMode>,
+// );
+root.render(<App />);

--- a/packages/openfeature-server-provider/src/ConfidenceServerProvider.ts
+++ b/packages/openfeature-server-provider/src/ConfidenceServerProvider.ts
@@ -42,7 +42,7 @@ export class ConfidenceServerProvider implements Provider {
     }
     return evaluation;
   }
-  private mapErrorCode(errorCode: 'FLAG_NOT_FOUND' | 'TYPE_MISMATCH' | 'NOT_READY' | 'GENERAL'): ErrorCode {
+  private mapErrorCode(errorCode: FlagEvaluation.ErrorCode): ErrorCode {
     switch (errorCode) {
       case 'FLAG_NOT_FOUND':
         return ErrorCode.FLAG_NOT_FOUND;

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.e2e.test.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.e2e.test.ts
@@ -30,11 +30,10 @@ describe('ConfidenceWebProvider E2E tests', () => {
       const client = OpenFeature.getClient();
 
       expect(client.getStringDetails('web-sdk-e2e-flag.str', 'default')).toEqual({
-        errorCode: 'PROVIDER_NOT_READY',
+        errorCode: 'GENERAL',
         flagKey: 'web-sdk-e2e-flag.str',
         flagMetadata: {},
-        errorMessage: 'Flags are not yet ready',
-        then: expect.any(Function),
+        errorMessage: 'Resolve timeout',
         reason: 'ERROR',
         value: 'default',
       });

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.test.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.test.ts
@@ -3,9 +3,6 @@ import { ConfidenceWebProvider } from './ConfidenceWebProvider';
 import { FlagResolver, StateObserver } from '@spotify-confidence/sdk';
 
 const confidenceMock: jest.Mocked<FlagResolver> = {
-  config: {
-    timeout: 10,
-  },
   getContext: jest.fn(),
   setContext: jest.fn(),
   withContext: jest.fn(),
@@ -25,10 +22,8 @@ describe('ConfidenceProvider', () => {
     instanceUnderTest = new ConfidenceWebProvider(confidenceMock);
 
     // subscribe will by default immediately emit READY
-    confidenceMock.subscribe.mockImplementation((...args) => {
-      const observer = args.pop();
-      if (typeof observer !== 'function') throw new Error('expected StateObserver in test');
-      observer('READY');
+    confidenceMock.subscribe.mockImplementation(observer => {
+      observer!('READY');
       return jest.fn();
     });
   });
@@ -37,14 +32,6 @@ describe('ConfidenceProvider', () => {
     it('should resolve if the state is ready', async () => {
       await expect(instanceUnderTest.initialize({ targetingKey: 'test' })).toResolve();
     });
-    it('should reject with timeout if state does not become ready', async () => {
-      // subscribe that never emits ready
-      confidenceMock.subscribe.mockImplementation(() => jest.fn());
-      await expect(instanceUnderTest.initialize({ targetingKey: 'test' })).rejects.toThrow(
-        'Resolve timed out after 10ms',
-      );
-    });
-
     it('should not set confidence context id no initial context', async () => {
       await instanceUnderTest.initialize();
       expect(confidenceMock.setContext).not.toHaveBeenCalled();

--- a/packages/sdk/src/Confidence.test.ts
+++ b/packages/sdk/src/Confidence.test.ts
@@ -33,6 +33,7 @@ describe('Confidence', () => {
       const flagResolution = new Promise<FlagResolution>(resolve => {
         setTimeout(() => {
           resolve({
+            state: 'READY',
             context: context,
             evaluate: jest.fn().mockImplementation(() => matchedEvaluation),
           });
@@ -357,6 +358,7 @@ describe('Confidence', () => {
 
     it('should handle a synchronously resolved promise', async () => {
       const mockFlagResolution: FlagResolution = {
+        state: 'READY',
         context: {},
         evaluate: jest.fn().mockImplementation(() => matchedEvaluation),
       };

--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -77,7 +77,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
         this.resolveFlags().then(reportState);
       }
       const close = this.contextChanges(() => {
-        if (this.flagState === 'READY') observer('STALE');
+        if (this.flagState === 'READY' || this.flagState === 'ERROR') observer('STALE');
         this.resolveFlags().then(reportState);
       });
 
@@ -269,7 +269,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
       region,
     });
     if (environment === 'client') {
-      flagResolverClient = new CachingFlagResolverClient(flagResolverClient, 3600_000);
+      flagResolverClient = new CachingFlagResolverClient(flagResolverClient, 30_000);
     }
     const estEventSizeKb = 1;
     const flushTimeoutMilliseconds = 500;

--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -175,7 +175,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
         })
         .catch(e => {
           // TODO fix sloppy handling of error
-          if (e.message !== 'Resolve aborted') {
+          if (e.name !== 'AbortError') {
             this.config.logger.info?.('Resolve failed.', e);
           }
         })
@@ -194,7 +194,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
   get flagState(): State {
     if (this.currentFlags) {
       if (this.pendingFlags) return 'STALE';
-      return 'READY';
+      return this.currentFlags.state;
     }
     return 'NOT_READY';
   }
@@ -208,14 +208,10 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
 
   private evaluateFlagAsync<T extends Value>(path: string, defaultValue: T): Promise<FlagEvaluation.Resolved<T>> {
     let close: () => void;
-    return new Promise<FlagEvaluation.Resolved<T>>((resolve, reject) => {
-      const timeoutId = setTimeout(() => {
-        reject(new Error(`Timeout evaluating flag "${path}"`));
-      }, this.config.timeout);
+    return new Promise<FlagEvaluation.Resolved<T>>(resolve => {
       close = this.subscribe(state => {
         // when state is ready we can be sure currentFlags exist
-        if (state === 'READY') {
-          clearTimeout(timeoutId);
+        if (state === 'READY' || state === 'ERROR') {
           resolve(this.currentFlags!.evaluate(path, defaultValue));
         }
       });
@@ -269,10 +265,11 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
       fetchImplementation,
       sdk,
       environment,
+      resolveTimeout: timeout,
       region,
     });
     if (environment === 'client') {
-      flagResolverClient = new CachingFlagResolverClient(flagResolverClient, 30_000);
+      flagResolverClient = new CachingFlagResolverClient(flagResolverClient, 3600_000);
     }
     const estEventSizeKb = 1;
     const flushTimeoutMilliseconds = 500;

--- a/packages/sdk/src/FlagResolution.ts
+++ b/packages/sdk/src/FlagResolution.ts
@@ -116,11 +116,7 @@ ReadyFlagResolution.prototype.state = 'READY';
 
 class FailedFlagResolution implements FlagResolution {
   declare state: 'ERROR';
-  constructor(
-    readonly context: Value.Struct,
-    readonly code: FlagEvaluation.ErrorCode,
-    readonly message: string,
-  ) {}
+  constructor(readonly context: Value.Struct, readonly code: FlagEvaluation.ErrorCode, readonly message: string) {}
 
   evaluate<T extends Value>(_path: string, defaultValue: T): FlagEvaluation.Resolved<T> {
     return {

--- a/packages/sdk/src/FlagResolution.ts
+++ b/packages/sdk/src/FlagResolution.ts
@@ -8,14 +8,19 @@ import { ResolveReason } from './generated/confidence/flags/resolver/v1/types';
 const FLAG_PREFIX = 'flags/';
 
 export interface FlagResolution {
+  readonly state: 'READY' | 'ERROR';
   readonly context: Value.Struct;
   // readonly flagNames:string[]
   evaluate<T extends Value>(path: string, defaultValue: T): FlagEvaluation.Resolved<T>;
 }
 
 export namespace FlagResolution {
-  export function create(context: Value.Struct, response: ResolveFlagsResponse, applier?: Applier): FlagResolution {
-    return new FlagResolutionImpl(context, response, applier);
+  export function ready(context: Value.Struct, response: ResolveFlagsResponse, applier?: Applier): FlagResolution {
+    return new ReadyFlagResolution(context, response, applier);
+  }
+
+  export function failed(context: Value.Struct, code: FlagEvaluation.ErrorCode, message: string): FlagResolution {
+    return new FailedFlagResolution(context, code, message);
   }
 }
 
@@ -35,11 +40,10 @@ type ResolvedFlag = {
 
 export type Applier = (flagName: string) => void;
 
-export class FlagResolutionImpl implements FlagResolution {
+export class ReadyFlagResolution implements FlagResolution {
   private readonly flags: Map<string, ResolvedFlag> = new Map();
-  // private readonly cachedEvaluations: Map<string, [defaultValue: any, evaluation: FlagEvaluation.Resolved<any>]> =
-  //   new Map();
   readonly resolveToken: string;
+  declare state: 'READY';
 
   constructor(
     readonly context: Value.Struct,
@@ -60,7 +64,7 @@ export class FlagResolutionImpl implements FlagResolution {
     this.resolveToken = base64FromBytes(resolveResponse.resolveToken);
   }
 
-  doEvaluate<T extends Value>(path: string, defaultValue: T): FlagEvaluation.Resolved<T> {
+  evaluate<T extends Value>(path: string, defaultValue: T): FlagEvaluation.Resolved<T> {
     try {
       const [name, ...steps] = path.split('.');
       const flag = this.flags.get(name);
@@ -106,21 +110,28 @@ export class FlagResolutionImpl implements FlagResolution {
       };
     }
   }
-  evaluate<T extends Value>(path: string, defaultValue: T): FlagEvaluation.Resolved<T> {
-    return this.doEvaluate(path, defaultValue);
-    // let entry = this.cachedEvaluations.get(path);
-    // if (!entry || !Value.equal(entry[0], defaultValue)) {
-    //   entry = [defaultValue, this.doEvaluate(path, defaultValue)];
-    //   // entry[1].id = Date.now();
-    //   this.cachedEvaluations.set(path, entry);
-    // }
-    // return entry[1];
-  }
+}
 
-  getValue<T extends Value>(path: string, defaultValue: T): T {
-    return this.evaluate(path, defaultValue).value;
+ReadyFlagResolution.prototype.state = 'READY';
+
+class FailedFlagResolution implements FlagResolution {
+  declare state: 'ERROR';
+  constructor(
+    readonly context: Value.Struct,
+    readonly code: FlagEvaluation.ErrorCode,
+    readonly message: string,
+  ) {}
+
+  evaluate<T extends Value>(_path: string, defaultValue: T): FlagEvaluation.Resolved<T> {
+    return {
+      reason: 'ERROR',
+      value: defaultValue,
+      errorCode: this.code,
+      errorMessage: this.message,
+    };
   }
 }
+FailedFlagResolution.prototype.state = 'ERROR';
 
 function toEvaluationReason(reason: ResolveReason): Exclude<FlagEvaluation<unknown>['reason'], 'PENDING'> {
   switch (reason) {

--- a/packages/sdk/src/FlagResolverClient.test.ts
+++ b/packages/sdk/src/FlagResolverClient.test.ts
@@ -48,6 +48,7 @@ describe('Client environment Evaluation', () => {
       version: 'test',
     },
     environment: 'client',
+    resolveTimeout: 10,
   });
 
   describe('apply', () => {
@@ -99,6 +100,7 @@ describe('Backend environment Evaluation', () => {
       version: 'test',
     },
     environment: 'backend',
+    resolveTimeout: 10,
   });
 
   it('should resolve a full flag object', async () => {

--- a/packages/sdk/src/FlagResolverClient.ts
+++ b/packages/sdk/src/FlagResolverClient.ts
@@ -305,6 +305,7 @@ export function withRequestLogic(fetchImplementation: (request: Request) => Prom
 function withTimeout(signal: AbortSignal, timeout: number, reason?: any): AbortSignal {
   const controller = new AbortController();
   const timeoutId: NodeJS.Timeout | number = setTimeout(() => controller.abort(reason), timeout);
+  // in Node setTimeout returns an object, with an unref function which will prevent the timeout from keeping the process alive
   if (typeof timeoutId === 'object') timeoutId.unref();
   signal.addEventListener('abort', () => {
     clearTimeout(timeoutId);

--- a/packages/sdk/src/FlagResolverClient.ts
+++ b/packages/sdk/src/FlagResolverClient.ts
@@ -16,7 +16,10 @@ import { SimpleFetch } from './types';
 const FLAG_PREFIX = 'flags/';
 
 export class ResolveError extends Error {
-  constructor(public readonly code: FlagEvaluation.ErrorCode, message: string) {
+  constructor(
+    public readonly code: FlagEvaluation.ErrorCode,
+    message: string,
+  ) {
     super(message);
   }
 }
@@ -135,7 +138,6 @@ export class FetchingFlagResolverClient implements FlagResolverClient {
             return FlagResolution.failed(context, error.code, error.message);
           }
           throw error;
-          // return FlagResolution.failed(context, 'GENERAL', error.message);
         });
     });
   }

--- a/packages/sdk/src/FlagResolverClient.ts
+++ b/packages/sdk/src/FlagResolverClient.ts
@@ -16,10 +16,7 @@ import { SimpleFetch } from './types';
 const FLAG_PREFIX = 'flags/';
 
 export class ResolveError extends Error {
-  constructor(
-    public readonly code: FlagEvaluation.ErrorCode,
-    message: string,
-  ) {
+  constructor(public readonly code: FlagEvaluation.ErrorCode, message: string) {
     super(message);
   }
 }

--- a/packages/sdk/src/flags.ts
+++ b/packages/sdk/src/flags.ts
@@ -2,6 +2,7 @@ import { Contextual } from '.';
 import { Value } from './Value';
 
 export namespace FlagEvaluation {
+  export type ErrorCode = 'FLAG_NOT_FOUND' | 'TYPE_MISMATCH' | 'NOT_READY' | 'TIMEOUT' | 'GENERAL';
   export interface Matched<T> {
     readonly reason: 'MATCH';
     readonly value: T;
@@ -21,7 +22,7 @@ export namespace FlagEvaluation {
   export interface Failed<T> {
     readonly reason: 'ERROR';
     readonly value: T;
-    readonly errorCode: 'FLAG_NOT_FOUND' | 'TYPE_MISMATCH' | 'NOT_READY' | 'GENERAL';
+    readonly errorCode: ErrorCode;
     readonly errorMessage: string;
   }
 
@@ -34,10 +35,6 @@ export type FlagEvaluation<T> = FlagEvaluation.Resolved<T> | FlagEvaluation.Stal
 export type State = 'NOT_READY' | 'READY' | 'STALE' | 'ERROR';
 export type StateObserver = (state: State) => void;
 export interface FlagResolver extends Contextual<FlagResolver> {
-  readonly config: {
-    timeout: number;
-  };
-
   subscribe(onStateChange?: StateObserver): () => void;
 
   evaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<Value.Widen<T>>;

--- a/packages/sdk/src/observing.ts
+++ b/packages/sdk/src/observing.ts
@@ -1,5 +1,8 @@
 import { Closer } from './Closer';
 
+// This is a utility type which comes packaged with TS 5.4 and later.
+type NoInfer<T> = [T][T extends any ? 0 : never];
+
 export type Observer<T> = (value: T) => void;
 
 export type Subscribe<T> = (observer: Observer<T>) => Closer;
@@ -34,7 +37,7 @@ export function subject<T>(observable: Subscribe<T>): Subscribe<T> {
   };
 }
 
-export function changeObserver<T>(observer: Observer<T>, initialValue?: T): Observer<T> {
+export function changeObserver<T>(observer: Observer<T>, initialValue?: NoInfer<T>): Observer<T> {
   let prevValue: T | undefined = initialValue;
   return (value: T) => {
     if (!Object.is(value, prevValue)) {


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

Move resolve timeout functionality to the FlagResolverClient, which in turn fixes two problems:

1. Failing requests aren't any longer retried indefinitely.
2. Failed requests are now cached so that they also work with Reac Suspense.

Fixes #155 

