### PR TITLE
fix: invalid d.ts generation

### DIFF
--- a/packages/sdk/src/logger.ts
+++ b/packages/sdk/src/logger.ts
@@ -1,7 +1,7 @@
 export namespace Logger {
   type Mutable<T> = { -readonly [P in keyof T]: T[P] };
   const NOOP_LOGGER = Object.freeze({});
-  const LEVELS = ['trace', 'debug', 'info', 'warn', 'error'] as const;
+  export const LEVELS = ['trace', 'debug', 'info', 'warn', 'error'] as const;
   export type Fn = (message: string, ...optionalParams: any[]) => void;
   export type Level = (typeof LEVELS)[number];
 


### PR DESCRIPTION
Without the exported `LEVELS`, typescript is forced to generate an empty export statement, this in turn triggers a bug in the `api-extractor` bundle tool.