### PR TITLE
fix: shared requests aborted

### DIFF
--- a/packages/sdk/src/FlagResolverClient.test.ts
+++ b/packages/sdk/src/FlagResolverClient.test.ts
@@ -410,7 +410,6 @@ describe('CachingFlagResolverClient', () => {
     const firstResolution = cachingClient.resolve(context, []);
     const secondResolution = cachingClient.resolve(context, []);
     firstResolution.abort();
-    firstResolution.abort();
     expect(pendingResolution.signal.aborted).toBe(false);
     secondResolution.abort();
     expect(pendingResolution.signal.aborted).toBe(true);

--- a/packages/sdk/src/FlagResolverClient.ts
+++ b/packages/sdk/src/FlagResolverClient.ts
@@ -242,10 +242,6 @@ export class CachingFlagResolverClient implements FlagResolverClient {
         },
         { once: true },
       );
-
-      // value.catch(() => {
-      //   this.#cache.delete(key);
-      // });
     } else {
       entry.refCount++;
     }


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

Due to the client cache resolve requests can be shared. We keep a ref-count in the cache entries and clear the entry when the ref-count drops to zero. However we inadvertently aborted the original request as soon as any ref was aborted. Added tests to show this and a fix.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing
- [ ] Relevant documentation updated
- [ ] linter/style run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app
