### PR TITLE
fix: infinite in memory flag cache

### DIFF
--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -269,7 +269,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
       region,
     });
     if (environment === 'client') {
-      flagResolverClient = new CachingFlagResolverClient(flagResolverClient, 30_000);
+      flagResolverClient = new CachingFlagResolverClient(flagResolverClient, Number.POSITIVE_INFINITY);
     }
     const estEventSizeKb = 1;
     const flushTimeoutMilliseconds = 500;


### PR DESCRIPTION
This PR will make the `CachingFlagResolverClient` persist the cache in memory for an infinite time.