### PR TITLE
Docs: Add documentation to the SDK to resolve MD warnings

### DIFF
--- a/api/openfeature-server-provider.api.md
+++ b/api/openfeature-server-provider.api.md
@@ -13,33 +13,29 @@ import { ProviderMetadata } from '@openfeature/server-sdk';
 import { ProviderStatus } from '@openfeature/server-sdk';
 import { ResolutionDetails } from '@openfeature/server-sdk';
 
-// Warning: (ae-missing-release-tag) "ConfidenceServerProvider" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
+export type ConfidenceProviderFactoryOptions = {
+    region?: 'eu' | 'us';
+    fetchImplementation?: typeof fetch;
+    clientSecret: string;
+    timeout: number;
+};
+
+// @public
 export class ConfidenceServerProvider implements Provider {
     constructor(client: FlagResolver);
-    // (undocumented)
     readonly metadata: ProviderMetadata;
-    // (undocumented)
     resolveBooleanEvaluation(flagKey: string, defaultValue: boolean, context: EvaluationContext): Promise<ResolutionDetails<boolean>>;
-    // (undocumented)
     resolveNumberEvaluation(flagKey: string, defaultValue: number, context: EvaluationContext): Promise<ResolutionDetails<number>>;
-    // (undocumented)
     resolveObjectEvaluation<T extends JsonValue>(flagKey: string, defaultValue: T, context: EvaluationContext): Promise<ResolutionDetails<T>>;
-    // (undocumented)
     resolveStringEvaluation(flagKey: string, defaultValue: string, context: EvaluationContext): Promise<ResolutionDetails<string>>;
-    // (undocumented)
     status: ProviderStatus;
 }
 
-// Warning: (ae-forgotten-export) The symbol "ConfidenceProviderFactoryOptions" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "createConfidenceServerProvider" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "createConfidenceServerProvider" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export function createConfidenceServerProvider(options: ConfidenceProviderFactoryOptions): Provider;
 
-// @public (undocumented)
+// @public
 export function createConfidenceServerProvider(confidence: Confidence): Provider;
 
 // (No @packageDocumentation comment for this package)

--- a/api/openfeature-web-provider.api.md
+++ b/api/openfeature-web-provider.api.md
@@ -13,39 +13,26 @@ import { Provider } from '@openfeature/web-sdk';
 import { ProviderMetadata } from '@openfeature/web-sdk';
 import { ResolutionDetails } from '@openfeature/web-sdk';
 
-// Warning: (ae-missing-release-tag) "ConfidenceWebProvider" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export class ConfidenceWebProvider implements Provider {
     constructor(confidence: FlagResolver);
-    // (undocumented)
     readonly events: OpenFeatureEventEmitter;
-    // (undocumented)
     initialize(context?: EvaluationContext): Promise<void>;
-    // (undocumented)
     readonly metadata: ProviderMetadata;
-    // (undocumented)
     onClose(): Promise<void>;
-    // (undocumented)
     onContextChange(oldContext: EvaluationContext, newContext: EvaluationContext): Promise<void>;
-    // (undocumented)
     resolveBooleanEvaluation(flagKey: string, defaultValue: boolean): ResolutionDetails<boolean>;
-    // (undocumented)
     resolveNumberEvaluation(flagKey: string, defaultValue: number): ResolutionDetails<number>;
-    // (undocumented)
     resolveObjectEvaluation<T extends JsonValue>(flagKey: string, defaultValue: T): ResolutionDetails<T>;
-    // (undocumented)
     resolveStringEvaluation(flagKey: string, defaultValue: string): ResolutionDetails<string>;
 }
 
 // Warning: (ae-forgotten-export) The symbol "ConfidenceWebProviderOptions" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "createConfidenceWebProvider" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "createConfidenceWebProvider" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export function createConfidenceWebProvider(options: ConfidenceWebProviderOptions): Provider;
 
-// @public (undocumented)
+// @public
 export function createConfidenceWebProvider(confidence: Confidence): Provider;
 
 // (No @packageDocumentation comment for this package)

--- a/api/react.api.md
+++ b/api/react.api.md
@@ -17,10 +17,7 @@ import { StateObserver } from '@spotify-confidence/sdk';
 import { Trackable } from '@spotify-confidence/sdk';
 import { Value } from '@spotify-confidence/sdk';
 
-// Warning: (ae-missing-release-tag) "ConfidenceProvider" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "ConfidenceProvider" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export type ConfidenceProvider = FC<PropsWithChildren<{
     confidence: Confidence;
 }>> & {
@@ -29,75 +26,49 @@ export type ConfidenceProvider = FC<PropsWithChildren<{
     }>>;
 };
 
-// @public (undocumented)
+// @public
 export const ConfidenceProvider: ConfidenceProvider;
 
-// Warning: (ae-missing-release-tag) "ConfidenceReact" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export class ConfidenceReact implements EventSender, Trackable, FlagResolver {
     constructor(delegate: Confidence);
-    // (undocumented)
     clearContext({ transition }?: {
         transition?: boolean | undefined;
     }): void;
-    // (undocumented)
     get config(): Configuration;
-    // @internal (undocumented)
+    // @internal
     get contextState(): string;
-    // @internal (undocumented)
+    // @internal
     readonly delegate: Confidence;
-    // (undocumented)
     evaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<Value.Widen<T>>;
-    // (undocumented)
     getContext(): Context;
-    // (undocumented)
     getFlag<T extends Value>(path: string, defaultValue: T): Promise<Value.Widen<T>>;
-    // (undocumented)
     setContext(context: Context, { transition }?: {
         transition?: boolean | undefined;
     }): void;
-    // (undocumented)
     subscribe(onStateChange?: StateObserver | undefined): () => void;
-    // (undocumented)
     track(name: string, message?: Value.Struct): void;
-    // (undocumented)
     track(manager: Trackable.Manager): Closer;
-    // (undocumented)
     useContext(): Context;
-    // (undocumented)
     useEvaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<Value.Widen<T>>;
-    // (undocumented)
     useFlag<T extends Value>(path: string, defaultValue: T): Value.Widen<T>;
-    // (undocumented)
     useWithContext(context: Context): ConfidenceReact;
-    // (undocumented)
     withContext(context: Context): ConfidenceReact;
 }
 
-// Warning: (ae-missing-release-tag) "useConfidence" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export const useConfidence: () => ConfidenceReact;
 
-// Warning: (ae-missing-release-tag) "useConfidenceContext" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export function useConfidenceContext(confidence?: ConfidenceReact): Context;
 
-// Warning: (ae-missing-release-tag) "useEvaluateFlag" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export function useEvaluateFlag<T extends Value>(path: string, defaultValue: T, confidence?: ConfidenceReact): FlagEvaluation<Value.Widen<T>>;
 
-// Warning: (ae-missing-release-tag) "useFlag" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export function useFlag<T extends Value>(path: string, defaultValue: T, confidence?: ConfidenceReact): Value.Widen<T>;
 
-// Warning: (ae-missing-release-tag) "useWithContext" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export function useWithContext(context: Context, parent?: ConfidenceReact): ConfidenceReact;
 
 // (No @packageDocumentation comment for this package)

--- a/api/sdk.api.md
+++ b/api/sdk.api.md
@@ -4,108 +4,68 @@
 
 ```ts
 
-// Warning: (ae-missing-release-tag) "Closer" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "Closer" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export namespace Closer {
-    // (undocumented)
     export function combine(...closers: Closer[]): Closer;
 }
 
-// @public (undocumented)
+// @public
 export type Closer = () => void;
 
-// Warning: (ae-missing-release-tag) "Confidence" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export class Confidence implements EventSender, Trackable, FlagResolver {
     constructor(config: Configuration, parent?: Confidence);
-    // (undocumented)
     clearContext(): void;
-    // (undocumented)
     readonly config: Configuration;
     // Warning: (ae-forgotten-export) The symbol "Subscribe" needs to be exported by the entry point index.d.ts
     //
-    // @internal (undocumented)
+    // @internal
     readonly contextChanges: Subscribe<string[]>;
-    // (undocumented)
     static create({ clientSecret, region, timeout, environment, fetchImplementation, logger, }: ConfidenceOptions): Confidence;
-    // (undocumented)
     get environment(): string;
-    // (undocumented)
     evaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<Value.Widen<T>>;
-    // (undocumented)
     get flagState(): State;
-    // (undocumented)
     getContext(): Context;
-    // (undocumented)
     getFlag<T extends Value>(path: string, defaultValue: T): Promise<Value.Widen<T>>;
     // Warning: (ae-forgotten-export) The symbol "AccessiblePromise" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
     protected resolveFlags(): AccessiblePromise<void>;
-    // (undocumented)
     setContext(context: Context): boolean;
-    // (undocumented)
     subscribe(onStateChange?: StateObserver): () => void;
-    // (undocumented)
     track(name: string, data?: EventData): void;
-    // (undocumented)
     track(manager: Trackable.Manager): Closer;
-    // (undocumented)
     withContext(context: Context): Confidence;
 }
 
-// Warning: (ae-missing-release-tag) "ConfidenceOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface ConfidenceOptions {
-    // (undocumented)
     clientSecret: string;
-    // (undocumented)
     environment: 'client' | 'backend';
     // Warning: (ae-forgotten-export) The symbol "SimpleFetch" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
     fetchImplementation?: SimpleFetch;
     // Warning: (ae-forgotten-export) The symbol "Logger" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
     logger?: Logger;
-    // (undocumented)
     region?: 'eu' | 'us';
-    // (undocumented)
     resolveUrl?: string;
-    // (undocumented)
     timeout: number;
 }
 
-// Warning: (ae-missing-release-tag) "Configuration" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface Configuration {
-    // (undocumented)
     readonly environment: 'client' | 'backend';
     // Warning: (ae-forgotten-export) The symbol "EventSenderEngine" needs to be exported by the entry point index.d.ts
     //
-    // @internal (undocumented)
+    // @internal
     readonly eventSenderEngine: EventSenderEngine;
     // Warning: (ae-forgotten-export) The symbol "FlagResolverClient" needs to be exported by the entry point index.d.ts
     //
-    // @internal (undocumented)
+    // @internal
     readonly flagResolverClient: FlagResolverClient;
-    // (undocumented)
     readonly logger: Logger;
-    // (undocumented)
     readonly timeout: number;
 }
 
-// Warning: (ae-missing-release-tag) "Context" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface Context extends Value.Struct {
-    // (undocumented)
     page?: {
         path: string;
         referrer: string;
@@ -113,194 +73,119 @@ export interface Context extends Value.Struct {
         title: string;
         url: string;
     };
-    // (undocumented)
     targeting_key?: string;
-    // (undocumented)
     visitor_id?: string;
 }
 
-// Warning: (ae-missing-release-tag) "Contextual" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface Contextual<Self extends Contextual<Self>> {
-    // (undocumented)
     clearContext(): void;
-    // (undocumented)
     getContext(): Context;
-    // (undocumented)
     setContext(context: Context): void;
-    // (undocumented)
     withContext(context: Context): Self;
 }
 
-// Warning: (ae-missing-release-tag) "EventData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export type EventData = Value.Struct & {
     context?: never;
 };
 
-// Warning: (ae-missing-release-tag) "EventSender" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface EventSender extends Contextual<EventSender> {
-    // (undocumented)
     track(name: string, data?: EventData): void;
 }
 
 // Warning: (ae-missing-release-tag) "FlagEvaluation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "FlagEvaluation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export namespace FlagEvaluation {
-    // (undocumented)
     export type ErrorCode = 'FLAG_NOT_FOUND' | 'TYPE_MISMATCH' | 'NOT_READY' | 'TIMEOUT' | 'GENERAL';
-    // (undocumented)
     export interface Failed<T> {
-        // (undocumented)
         readonly errorCode: ErrorCode;
-        // (undocumented)
         readonly errorMessage: string;
-        // (undocumented)
         readonly reason: 'ERROR';
-        // (undocumented)
         readonly value: T;
     }
-    // (undocumented)
     export interface Matched<T> {
-        // (undocumented)
         readonly reason: 'MATCH';
-        // (undocumented)
         readonly value: T;
-        // (undocumented)
         readonly variant: string;
     }
-    // (undocumented)
     export type Resolved<T> = Matched<T> | Unmatched<T> | Failed<T>;
-    // (undocumented)
     export type Stale<T> = Resolved<T> & PromiseLike<Resolved<T>>;
-    // (undocumented)
     export interface Unmatched<T> {
-        // (undocumented)
         readonly reason: 'UNSPECIFIED' | 'NO_SEGMENT_MATCH' | 'NO_TREATMENT_MATCH' | 'FLAG_ARCHIVED' | 'TARGETING_KEY_ERROR';
-        // (undocumented)
         readonly value: T;
     }
 }
 
-// @public (undocumented)
+// @public
 export type FlagEvaluation<T> = FlagEvaluation.Resolved<T> | FlagEvaluation.Stale<T>;
 
-// Warning: (ae-missing-release-tag) "FlagResolver" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface FlagResolver extends Contextual<FlagResolver> {
-    // (undocumented)
     evaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<Value.Widen<T>>;
-    // (undocumented)
     getFlag<T extends Value>(path: string, defaultValue: T): Promise<Value.Widen<T>>;
-    // (undocumented)
     subscribe(onStateChange?: StateObserver): () => void;
 }
 
-// Warning: (ae-missing-release-tag) "pageViews" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export function pageViews(): Trackable.Manager;
 
-// Warning: (ae-missing-release-tag) "State" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export type State = 'NOT_READY' | 'READY' | 'STALE' | 'ERROR';
 
-// Warning: (ae-missing-release-tag) "StateObserver" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export type StateObserver = (state: State) => void;
 
-// Warning: (ae-missing-release-tag) "Trackable" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "Trackable" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export namespace Trackable {
-    // (undocumented)
     export type Cleanup = void | Closer;
-    // (undocumented)
     export type Controller = Pick<Confidence, 'setContext' | 'track' | 'config'>;
-    // (undocumented)
     export type Manager = (controller: Controller) => Cleanup;
-    // (undocumented)
     export function setup(controller: Controller, manager: Manager): Closer;
 }
 
-// @public (undocumented)
+// @public
 export interface Trackable {
-    // (undocumented)
     track(manager: Trackable.Manager): Closer;
 }
 
 // Warning: (ae-missing-release-tag) "Value" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "Value" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export namespace Value {
-    // (undocumented)
     export function assertType(expected: 'undefined', found: Value): asserts found is undefined;
-    // (undocumented)
     export function assertType(expected: 'string', found: Value): asserts found is string;
-    // (undocumented)
     export function assertType(expected: 'number', found: Value): asserts found is number;
-    // (undocumented)
     export function assertType(expected: 'boolean', found: Value): asserts found is boolean;
-    // (undocumented)
     export function assertType(expected: 'List', found: Value): asserts found is List;
-    // (undocumented)
     export function assertType(expected: 'Struct', found: Value): asserts found is Struct;
-    // (undocumented)
     export function assertValue(value: unknown): asserts value is Value;
-    // (undocumented)
     export function clone<T extends Value>(value: T): T;
-    // (undocumented)
     export function deserialize(data: string): Value;
-    // (undocumented)
     export function equal(value1: Value, value2: Value): boolean;
-    // (undocumented)
     export function get(struct: Struct | undefined, path: string): Value;
-    // (undocumented)
     export function get(struct: Struct | undefined, ...steps: string[]): Value;
-    // (undocumented)
     export function getType(value: Value): TypeName;
-    // (undocumented)
     export function isList(value: Value): value is List;
-    // (undocumented)
     export function isStruct(value: Value): value is Struct;
-    // (undocumented)
     export type List = ReadonlyArray<number> | ReadonlyArray<string> | ReadonlyArray<boolean>;
-    // (undocumented)
     export type Primitive = number | string | boolean;
-    // (undocumented)
     export function serialize(value: Value): string;
-    // (undocumented)
     export type Struct = {
         readonly [key: string]: Value;
     };
-    // (undocumented)
     export type TypeName = 'number' | 'string' | 'boolean' | 'Struct' | 'List' | 'undefined';
-    // (undocumented)
     export type Widen<T extends Value> = T extends number ? number : T extends string ? string : T extends boolean ? boolean : T;
 }
 
-// @public (undocumented)
+// @public
 export type Value = Value.Primitive | Value.Struct | Value.List | undefined;
 
-// Warning: (ae-missing-release-tag) "visitorIdentity" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export const visitorIdentity: () => Trackable.Manager;
 
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@spotify-confidence/sdk" does not have an export "Topic"
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The reference is ambiguous because "track" has more than one declaration; you need to add a TSDoc member reference selector
-//
 // @public
 export function webVitals({ lcp, inp, cls, ttfb, }?: WebVitalsOptions): Trackable.Manager;
 

--- a/packages/openfeature-server-provider/src/ConfidenceServerProvider.ts
+++ b/packages/openfeature-server-provider/src/ConfidenceServerProvider.ts
@@ -13,10 +13,16 @@ import { Context, FlagEvaluation, FlagResolver, Value } from '@spotify-confidenc
 
 type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 
+/**
+ * Confidence Server Provider for OpenFeature SDK
+ * @public
+ */
 export class ConfidenceServerProvider implements Provider {
+  /** Static data about the provider */
   readonly metadata: ProviderMetadata = {
     name: 'ConfidenceServerProvider',
   };
+  /** Current status of the provider. Can be READY, NOT_READY, ERROR, STALE and FATAL. */
   status: ProviderStatus = ProviderStatus.READY;
   private readonly confidence: FlagResolver;
 
@@ -54,6 +60,7 @@ export class ConfidenceServerProvider implements Provider {
         return ErrorCode.GENERAL;
     }
   }
+  /** Resolves with an evaluation of a Boolean flag */
   resolveBooleanEvaluation(
     flagKey: string,
     defaultValue: boolean,
@@ -61,7 +68,7 @@ export class ConfidenceServerProvider implements Provider {
   ): Promise<ResolutionDetails<boolean>> {
     return this.fetchFlag(flagKey, defaultValue, context);
   }
-
+  /** Resolves with an evaluation of a Numbers flag */
   resolveNumberEvaluation(
     flagKey: string,
     defaultValue: number,
@@ -69,7 +76,7 @@ export class ConfidenceServerProvider implements Provider {
   ): Promise<ResolutionDetails<number>> {
     return this.fetchFlag(flagKey, defaultValue, context);
   }
-
+  /** Resolves with an evaluation of an Object flag */
   resolveObjectEvaluation<T extends JsonValue>(
     flagKey: string,
     defaultValue: T,
@@ -78,7 +85,7 @@ export class ConfidenceServerProvider implements Provider {
     Value.assertValue(defaultValue);
     return this.fetchFlag(flagKey, defaultValue, context);
   }
-
+  /** Resolves with an evaluation of a String flag */
   resolveStringEvaluation(
     flagKey: string,
     defaultValue: string,

--- a/packages/openfeature-server-provider/src/ConfidenceServerProvider.ts
+++ b/packages/openfeature-server-provider/src/ConfidenceServerProvider.ts
@@ -14,7 +14,7 @@ import { Context, FlagEvaluation, FlagResolver, Value } from '@spotify-confidenc
 type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 
 /**
- * Confidence Server Provider for OpenFeature SDK
+ * OpenFeature Provider for Confidence Server SDK
  * @public
  */
 export class ConfidenceServerProvider implements Provider {

--- a/packages/openfeature-server-provider/src/factory.ts
+++ b/packages/openfeature-server-provider/src/factory.ts
@@ -2,15 +2,30 @@ import { Provider } from '@openfeature/server-sdk';
 import { ConfidenceServerProvider } from './ConfidenceServerProvider';
 import { Confidence } from '@spotify-confidence/sdk';
 
-type ConfidenceProviderFactoryOptions = {
+/**
+ * Factory Options for Confidence Server Provider
+ * @public */
+export type ConfidenceProviderFactoryOptions = {
   region?: 'eu' | 'us';
   fetchImplementation?: typeof fetch;
   clientSecret: string;
   timeout: number;
 };
 
+/**
+ * Creates an OpenFeature-adhering Confidence Provider
+ * @param options - Options for Confidence Provider
+ * @public */
 export function createConfidenceServerProvider(options: ConfidenceProviderFactoryOptions): Provider;
+/**
+ * Creates an OpenFeature-adhering Confidence Provider
+ * @param confidence - Confidence instance
+ * @public */
 export function createConfidenceServerProvider(confidence: Confidence): Provider;
+/**
+ * Creates an OpenFeature-adhering Confidence Provider
+ * @param confidenceOrOptions - Confidence instance or options for Confidence Provider
+ * @public */
 export function createConfidenceServerProvider(
   confidenceOrOptions: Confidence | ConfidenceProviderFactoryOptions,
 ): Provider {

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
@@ -16,7 +16,7 @@ import { Value, Context, FlagResolver, FlagEvaluation } from '@spotify-confidenc
 type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 
 /**
- * Confidence Web Provider for OpenFeature SDK
+ * OpenFeature Provider for Confidence Web SDK
  * @public
  */
 export class ConfidenceWebProvider implements Provider {
@@ -53,7 +53,7 @@ export class ConfidenceWebProvider implements Provider {
     return this.expectReadyOrError();
   }
 
-  /** Function called on closing of a Provider, handles unsubscribing from the Provider */
+  /** Function called on closing of a Provider, handles unsubscribing from the Confidence SDK */
   async onClose(): Promise<void> {
     this.unsubscribe?.();
     this.unsubscribe = undefined;

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
@@ -15,10 +15,16 @@ import { Value, Context, FlagResolver, FlagEvaluation } from '@spotify-confidenc
 
 type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 
+/**
+ * Confidence Web Provider for OpenFeature SDK
+ * @public
+ */
 export class ConfidenceWebProvider implements Provider {
+  /** Static data about the provider */
   readonly metadata: ProviderMetadata = {
     name: 'ConfidenceWebProvider',
   };
+  /** Events can be used by developers to track lifecycle events */
   readonly events = new OpenFeatureEventEmitter();
 
   private unsubscribe?: () => void;
@@ -28,6 +34,7 @@ export class ConfidenceWebProvider implements Provider {
     this.confidence = confidence;
   }
 
+  /** Initialize the Provider */
   async initialize(context?: EvaluationContext): Promise<void> {
     if (context) this.confidence.setContext(convertContext(context));
     let isStale = false;
@@ -46,11 +53,13 @@ export class ConfidenceWebProvider implements Provider {
     return this.expectReadyOrError();
   }
 
+  /** Function called on closing of a Provider, handles unsubscribing from the Provider */
   async onClose(): Promise<void> {
     this.unsubscribe?.();
     this.unsubscribe = undefined;
   }
 
+  /** Called on Confidence Context change */
   async onContextChange(oldContext: EvaluationContext, newContext: EvaluationContext): Promise<void> {
     const changes = contextChanges(oldContext, newContext);
     if (Object.keys(changes).length === 0) {
@@ -98,20 +107,24 @@ export class ConfidenceWebProvider implements Provider {
     }
   }
 
+  /** Resolves with an evaluation of a Boolean flag */
   resolveBooleanEvaluation(flagKey: string, defaultValue: boolean): ResolutionDetails<boolean> {
     return this.evaluateFlag(flagKey, defaultValue);
   }
 
+  /** Resolves with an evaluation of a Number flag */
   resolveNumberEvaluation(flagKey: string, defaultValue: number): ResolutionDetails<number> {
     return this.evaluateFlag(flagKey, defaultValue);
   }
 
+  /** Resolves with an evaluation of an Object flag */
   resolveObjectEvaluation<T extends JsonValue>(flagKey: string, defaultValue: T): ResolutionDetails<T> {
     // this might throw but will be caught by OpenFeature
     Value.assertValue(defaultValue);
     return this.evaluateFlag(flagKey, defaultValue);
   }
 
+  /** Resolves with an evaluation of a String flag */
   resolveStringEvaluation(flagKey: string, defaultValue: string): ResolutionDetails<string> {
     return this.evaluateFlag(flagKey, defaultValue);
   }

--- a/packages/openfeature-web-provider/src/factory.ts
+++ b/packages/openfeature-web-provider/src/factory.ts
@@ -2,6 +2,9 @@ import { Provider } from '@openfeature/web-sdk';
 import { ConfidenceWebProvider } from './ConfidenceWebProvider';
 import { Confidence } from '@spotify-confidence/sdk';
 
+/**
+ * Factory Options for Confidence Web Provider
+ * @public */
 export type ConfidenceWebProviderOptions = {
   region?: 'eu' | 'us';
   fetchImplementation?: typeof fetch;
@@ -9,8 +12,20 @@ export type ConfidenceWebProviderOptions = {
   timeout: number;
 };
 
+/**
+ * Creates an OpenFeature-adhering Confidence Provider
+ * @param options - Options for Confidence Provider
+ * @public */
 export function createConfidenceWebProvider(options: ConfidenceWebProviderOptions): Provider;
+/**
+ * Creates an OpenFeature-adhering Confidence Provider
+ * @param confidence - Confidence instance
+ * @public */
 export function createConfidenceWebProvider(confidence: Confidence): Provider;
+/**
+ * Creates an OpenFeature-adhering Confidence Provider
+ * @param confidenceOrOptions - Confidence instance or options for Confidence Provider
+ * @public */
 export function createConfidenceWebProvider(confidenceOrOptions: Confidence | ConfidenceWebProviderOptions): Provider {
   if (confidenceOrOptions instanceof Confidence) {
     return new ConfidenceWebProvider(confidenceOrOptions);

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -170,10 +170,10 @@ export function useWithContext(context: Context, parent = useConfidence()): Conf
 // this would be better named useContext, but would then collide with React.useContext
 // eslint-disable-next-line react-hooks/rules-of-hooks
 export function useConfidenceContext(confidence = useConfidence()): Context {
-  const [, setState] = useState(confidence.contextState);
-  useEffect(() => {
-    return confidence.delegate.contextChanges(() => setState(confidence.contextState));
-  });
+  // const [, setState] = useState(confidence.contextState);
+  // useEffect(() => {
+  //   return confidence.delegate.contextChanges(() => setState(confidence.contextState));
+  // });
   return confidence.delegate.getContext();
 }
 

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -110,7 +110,7 @@ export class ConfidenceReact implements EventSender, Trackable, FlagResolver {
   }
 
   /**
-   * Creates a new Confidence instance with context
+   * Creates a new ConfidenceReact instance with context
    * @param context - Confidence context
    * @returns ConfidenceReact instance
    */
@@ -131,22 +131,22 @@ export class ConfidenceReact implements EventSender, Trackable, FlagResolver {
 
   /* eslint-disable react-hooks/rules-of-hooks */
 
-  /** Uses Context */
+  /** Hook to access Context */
   useContext(): Context {
     this.assertContext('useContext', 'getContext');
     return useConfidenceContext(this);
   }
-  /** Uses Context */
+  /** Hook to access the WithContext functionality. Returns a  ConfidenceReact instance with the passed context. */
   useWithContext(context: Context): ConfidenceReact {
     this.assertContext('useWithContext', 'withContext');
     return useWithContext(context, this);
   }
-  /** Uses EvaluateFlag */
+  /** Hook to use EvaluateFlag functionality */
   useEvaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<Value.Widen<T>> {
     this.assertContext('useEvaluateFlag', 'evaluateFlag');
     return useEvaluateFlag(path, defaultValue, this);
   }
-  /** Uses Flag */
+  /** Hook to use getFlag functionality */
   useFlag<T extends Value>(path: string, defaultValue: T): Value.Widen<T> {
     this.assertContext('useFlag', 'getFlag');
     return useFlag(path, defaultValue, this);

--- a/packages/sdk/src/Closer.ts
+++ b/packages/sdk/src/Closer.ts
@@ -12,9 +12,10 @@ export namespace Closer {
     };
   }
 }
-// eslint-disable-next-line @typescript-eslint/no-redeclare
+
 /**
  * Utility functions to manage Closer types
  * @public
  */
+// eslint-disable-next-line @typescript-eslint/no-redeclare
 export type Closer = () => void;

--- a/packages/sdk/src/Closer.ts
+++ b/packages/sdk/src/Closer.ts
@@ -1,4 +1,9 @@
+/**
+ * Utility functions to manage Closer types
+ * @public
+ */
 export namespace Closer {
+  /** Combine multiple closers */
   export function combine(...closers: Closer[]): Closer {
     return () => {
       for (const closer of closers) {
@@ -8,4 +13,8 @@ export namespace Closer {
   }
 }
 // eslint-disable-next-line @typescript-eslint/no-redeclare
+/**
+ * Utility functions to manage Closer types
+ * @public
+ */
 export type Closer = () => void;

--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -19,33 +19,60 @@ import { SimpleFetch } from './types';
 import { FlagResolution } from './FlagResolution';
 import { AccessiblePromise } from './AccessiblePromise';
 
+/**
+ * Confidence options, to be used for easier initialization of Confidence
+ * @public
+ *  */
 export interface ConfidenceOptions {
+  /** Client secret, to be found in Confidence console*/
   clientSecret: string;
+  /** Region in which Confidence will operate */
   region?: 'eu' | 'us';
+  /** Resolve URL */
   resolveUrl?: string;
+  /** Environment: can be either client of backend */
   environment: 'client' | 'backend';
+  /** Fetch implementation */
   fetchImplementation?: SimpleFetch;
+  /** Resolve timeout */
   timeout: number;
+  /** Debug logger */
   logger?: Logger;
 }
 
+/**
+ * Confidence configuration
+ * @public
+ */
 export interface Configuration {
+  /** Environment: can be either client of backend */
   readonly environment: 'client' | 'backend';
+  /** Debug logger */
   readonly logger: Logger;
+  /** Resolve timeout */
   readonly timeout: number;
-  /** @internal */
+  /** Event Sender Engine
+   * @internal */
   readonly eventSenderEngine: EventSenderEngine;
-  /** @internal */
+  /** Flag Resolver Client
+   * @internal */
   readonly flagResolverClient: FlagResolverClient;
 }
 
+/**
+ * Class containing main Confidence APIs
+ * @public
+ */
 export class Confidence implements EventSender, Trackable, FlagResolver {
+  /** Internal Confidence configurations */
   readonly config: Configuration;
   private readonly parent?: Confidence;
   private _context: Map<string, Value> = new Map();
   private contextChanged?: Observer<string[]>;
 
-  /** @internal */
+  /**
+   * Emits Closers on context change
+   * @internal */
   readonly contextChanges: Subscribe<string[]>;
 
   private currentFlags?: FlagResolution;
@@ -89,6 +116,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     });
   }
 
+  /** Returns currently used environment */
   get environment(): string {
     return this.config.environment;
   }
@@ -114,6 +142,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     }
   }
 
+  /** Returns context of the current Confidence instance */
   getContext(): Context {
     const context: Record<string, Value> = {};
     for (const [key, value] of this.contextEntries()) {
@@ -122,6 +151,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     return Object.freeze(context);
   }
 
+  /** Set Confidence context */
   setContext(context: Context): boolean {
     const current = this.getContext();
     const changedKeys: string[] = [];
@@ -136,6 +166,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     return changedKeys.length > 0;
   }
 
+  /** Clears context of current Confidence instance */
   clearContext(): void {
     const oldContext = this.getContext();
     this._context.clear();
@@ -147,6 +178,11 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     }
   }
 
+  /**
+   * Creates a new Confidence instance with context
+   * @param context - Confidence context
+   * @returns Confidence instance
+   */
   withContext(context: Context): Confidence {
     const child = new Confidence(this.config, this);
     child.setContext(context);
@@ -154,8 +190,22 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     return child;
   }
 
+  /**
+   * Tracks an event
+   * @param name - event name
+   * @param data - data to track */
   track(name: string, data?: EventData): void;
+  /**
+   * Tracks an event
+   * @param manager - event manager
+   */
   track(manager: Trackable.Manager): Closer;
+  /**
+   * Tracks an event
+   * @param nameOrManager - event name of event manager
+   * @param data - data to track
+   * @returns - Closer
+   */
   track(nameOrManager: string | Trackable.Manager, data?: EventData): Closer | undefined {
     if (typeof nameOrManager === 'function') {
       return Trackable.setup(this, nameOrManager);
@@ -164,6 +214,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     return undefined;
   }
 
+  /** Resolves all flags in cache */
   protected resolveFlags(): AccessiblePromise<void> {
     const context = this.getContext();
     if (!this.pendingFlags || !Value.equal(this.pendingFlags.context, context)) {
@@ -191,6 +242,10 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     return this.pendingFlags;
   }
 
+  /**
+   * Shows flag state
+   * @returns flag state - READY, NOT_READY, STALE or ERROR
+   */
   get flagState(): State {
     if (this.currentFlags) {
       if (this.pendingFlags) return 'STALE';
@@ -199,6 +254,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     return 'NOT_READY';
   }
 
+  /** Subscribe to flag changes in Confidence */
   subscribe(onStateChange: StateObserver = () => {}): () => void {
     const observer = changeObserver(onStateChange);
     const close = this.flagStateSubject(observer);
@@ -218,6 +274,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     }).finally(close!);
   }
 
+  /** Evaluates a flag */
   evaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<Value.Widen<T>> {
     let evaluation: FlagEvaluation<T>;
     // resolveFlags might update state synchronously
@@ -244,10 +301,21 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     return evaluation as FlagEvaluation<Value.Widen<T>>;
   }
 
+  /** Returns flag value for a given flag */
   async getFlag<T extends Value>(path: string, defaultValue: T): Promise<Value.Widen<T>> {
     return (await this.evaluateFlag(path, defaultValue)).value;
   }
 
+  /**
+   * Creates a Confidence instance
+   * @param clientSecret - clientSecret found on the Confidence console
+   * @param region - region in which Confidence will operate
+   * @param timeout - timeout for flag resolves
+   * @param environment - can be either "client" or "backend"
+   * @param fetchImplementation - fetch implementation
+   * @param logger - debug logger
+   * @returns
+   */
   static create({
     clientSecret,
     region,

--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -196,7 +196,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
    * @param data - data to track */
   track(name: string, data?: EventData): void;
   /**
-   * Tracks an event
+   * Sets up a Trackable.Manager to manage event tracking or context changes.
    * @param manager - event manager
    */
   track(manager: Trackable.Manager): Closer;

--- a/packages/sdk/src/Trackable.ts
+++ b/packages/sdk/src/Trackable.ts
@@ -3,9 +3,16 @@ import { Confidence } from './Confidence';
 import { Context } from './context';
 import { EventData } from './events';
 
+/**
+ * Namespace describing something to track
+ * @public
+ */
 export namespace Trackable {
+  /** Trackable Controller */
   export type Controller = Pick<Confidence, 'setContext' | 'track' | 'config'>;
+  /** Trackable Cleanup */
   export type Cleanup = void | Closer;
+  /** Trackable Manager */
   export type Manager = (controller: Controller) => Cleanup;
 
   class RevocableController implements Controller {
@@ -56,6 +63,7 @@ export namespace Trackable {
     }
   }
 
+  /** Setup of Trackable */
   export function setup(controller: Controller, manager: Manager): Closer {
     const revocableController = new RevocableController(controller);
     const cleanup = manager(revocableController);
@@ -69,6 +77,11 @@ export namespace Trackable {
     };
   }
 }
+/**
+ * Namespace describing something to track
+ * @public
+ */
 export interface Trackable {
+  /** Tracks an event given a Trackable Manager */
   track(manager: Trackable.Manager): Closer;
 }

--- a/packages/sdk/src/Value.ts
+++ b/packages/sdk/src/Value.ts
@@ -1,25 +1,35 @@
 import { TypeMismatchError } from './error';
 
+/**
+ * Namespace that describes Values used in Confidence
+ * @public
+ */
 export namespace Value {
   // TODO should lists be able to contain Structs?
   const LIST_ITEM_TYPES = new Set(['number', 'string', 'boolean']);
 
+  /** TypeName enum */
   export type TypeName = 'number' | 'string' | 'boolean' | 'Struct' | 'List' | 'undefined';
   // TODO add Date
+  /** Primitive types */
   export type Primitive = number | string | boolean;
+  /** Struct in Confidence */
   export type Struct = {
     readonly [key: string]: Value;
   };
+  /** Readonly List */
   export type List = ReadonlyArray<number> | ReadonlyArray<string> | ReadonlyArray<boolean>;
 
+  /** Sets Confidence used Values to be implementations of primitive types */
   export type Widen<T extends Value> = T extends number
     ? number
     : T extends string
-    ? string
-    : T extends boolean
-    ? boolean
-    : T;
+      ? string
+      : T extends boolean
+        ? boolean
+        : T;
 
+  /** Asserts a Value */
   export function assertValue(value: unknown): asserts value is Value {
     switch (typeof value) {
       case 'bigint':
@@ -52,6 +62,7 @@ export namespace Value {
     }
   }
 
+  /** Clones a Value */
   export function clone<T extends Value>(value: T): T {
     if (isStruct(value)) {
       const cloned: Record<string, Value> = {};
@@ -66,6 +77,7 @@ export namespace Value {
     return value;
   }
 
+  /** Asserts if two Values are equal */
   export function equal(value1: Value, value2: Value): boolean {
     if (value1 === value2) return true;
     const type = getType(value1);
@@ -97,6 +109,7 @@ export namespace Value {
     return true;
   }
 
+  /** Returns typename of given Value */
   export function getType(value: Value): TypeName {
     const jsType = typeof value;
     switch (jsType) {
@@ -112,20 +125,29 @@ export namespace Value {
     throw new TypeError(`Invalid Value type "${jsType}"`);
   }
 
+  /** Asserts that Value is a Struct */
   export function isStruct(value: Value): value is Struct {
     return Value.getType(value) === 'Struct';
   }
 
+  /** Asserts that Value is a List */
   export function isList(value: Value): value is List {
     return Value.getType(value) === 'List';
   }
 
+  /** Asserts that type of value is undefined */
   export function assertType(expected: 'undefined', found: Value): asserts found is undefined;
+  /** Asserts that type of value is string */
   export function assertType(expected: 'string', found: Value): asserts found is string;
+  /** Asserts that type of value is number */
   export function assertType(expected: 'number', found: Value): asserts found is number;
+  /** Asserts that type of value is boolean */
   export function assertType(expected: 'boolean', found: Value): asserts found is boolean;
+  /** Asserts that type of value is List */
   export function assertType(expected: 'List', found: Value): asserts found is List;
+  /** Asserts that type of value is Struct */
   export function assertType(expected: 'Struct', found: Value): asserts found is Struct;
+  /** Asserts that type of value is Value */
   export function assertType(expected: TypeName, found: Value): asserts found is Value {
     const actual = Value.getType(found);
     if (expected !== actual) {
@@ -133,8 +155,11 @@ export namespace Value {
     }
   }
 
+  /** Returns a Value given a Struct */
   export function get(struct: Struct | undefined, path: string): Value;
+  /** Returns a Value given a Struct */
   export function get(struct: Struct | undefined, ...steps: string[]): Value;
+  /** Returns a Value given a Struct */
   export function get(struct: Struct | undefined, ...parts: string[]): Value {
     let value: Value = struct;
     const errorPath: string[] = [];
@@ -150,12 +175,14 @@ export namespace Value {
     return value;
   }
 
+  /** Serializes value */
   export function serialize(value: Value): string {
     const writer = new Writer();
     writer.writeValue(value);
     return writer.data;
   }
 
+  /** Deserializes value */
   export function deserialize(data: string): Value {
     const reader = new Reader(data);
     return reader.readValue();
@@ -321,5 +348,6 @@ export namespace Value {
     }
   }
 }
+/** Confidence used Values */
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type Value = Value.Primitive | Value.Struct | Value.List | undefined;

--- a/packages/sdk/src/Value.ts
+++ b/packages/sdk/src/Value.ts
@@ -24,10 +24,10 @@ export namespace Value {
   export type Widen<T extends Value> = T extends number
     ? number
     : T extends string
-      ? string
-      : T extends boolean
-        ? boolean
-        : T;
+    ? string
+    : T extends boolean
+    ? boolean
+    : T;
 
   /** Asserts a Value */
   export function assertValue(value: unknown): asserts value is Value {

--- a/packages/sdk/src/context.ts
+++ b/packages/sdk/src/context.ts
@@ -1,15 +1,34 @@
 import { Value } from './Value';
 
+/**
+ * Interface that describes a Contextual
+ * @public
+ */
 export interface Contextual<Self extends Contextual<Self>> {
+  /** Returns context of the current Confidence instance */
   getContext(): Context;
+  /** Set Confidence context */
   setContext(context: Context): void;
+  /**
+   * Creates a new Confidence instance with context
+   * @param context - Confidence context
+   * @returns Confidence instance
+   */
   withContext(context: Context): Self;
+  /** Clears context of current Confidence instance */
   clearContext(): void;
 }
 
+/**
+ * Confidence context
+ * @public
+ */
 export interface Context extends Value.Struct {
+  /** Visitor id */
   visitor_id?: string;
+  /** Targeting key */
   targeting_key?: string;
+  /** Page metadata */
   page?: {
     path: string;
     referrer: string;

--- a/packages/sdk/src/events.ts
+++ b/packages/sdk/src/events.ts
@@ -1,8 +1,20 @@
 import { Value } from './Value';
 import { Contextual } from './context';
 
+/**
+ * Event data
+ * @public
+ */
 export type EventData = Value.Struct & { context?: never };
 
+/**
+ * EventSender interface
+ * @public
+ */
 export interface EventSender extends Contextual<EventSender> {
+  /**
+   * Tracks an event
+   * @param name - event name
+   * @param data - data to track */
   track(name: string, data?: EventData): void;
 }

--- a/packages/sdk/src/flags.ts
+++ b/packages/sdk/src/flags.ts
@@ -1,43 +1,77 @@
 import { Contextual } from '.';
 import { Value } from './Value';
 
+/**
+ * Flag evaluation identifiers
+ * @public
+ */
 export namespace FlagEvaluation {
+  /** Error code thrown in case flag couldn't be correctly evaluated */
   export type ErrorCode = 'FLAG_NOT_FOUND' | 'TYPE_MISMATCH' | 'NOT_READY' | 'TIMEOUT' | 'GENERAL';
+  /** Flag evaluation case of Matched */
   export interface Matched<T> {
+    /** Matched reason */
     readonly reason: 'MATCH';
+    /** Flag value */
     readonly value: T;
+    /** Flag variant */
     readonly variant: string;
   }
 
+  /** Flag evaluation case of Unmatched */
   export interface Unmatched<T> {
+    /** Unmatched reason */
     readonly reason:
       | 'UNSPECIFIED'
       | 'NO_SEGMENT_MATCH'
       | 'NO_TREATMENT_MATCH'
       | 'FLAG_ARCHIVED'
       | 'TARGETING_KEY_ERROR';
+    /** Flag value */
     readonly value: T;
   }
 
+  /** Flag evaluation case of Failed */
   export interface Failed<T> {
+    /** Failed reason */
     readonly reason: 'ERROR';
+    /** Flag value */
     readonly value: T;
+    /** Error code */
     readonly errorCode: ErrorCode;
+    /** Error message */
     readonly errorMessage: string;
   }
 
+  /** Flag evaluation case of Resolved */
   export type Resolved<T> = Matched<T> | Unmatched<T> | Failed<T>;
+  /** Flag evaluation case of Stale */
   export type Stale<T> = Resolved<T> & PromiseLike<Resolved<T>>;
 }
+/** Flag evaluation */
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type FlagEvaluation<T> = FlagEvaluation.Resolved<T> | FlagEvaluation.Stale<T>;
 
+/**
+ * Flags states
+ * @public
+ */
 export type State = 'NOT_READY' | 'READY' | 'STALE' | 'ERROR';
+/**
+ * Flag state observer
+ * @public */
 export type StateObserver = (state: State) => void;
+/**
+ * Flag Resolver interface
+ * @public
+ */
 export interface FlagResolver extends Contextual<FlagResolver> {
+  /** Subscribe to flag changes in Confidence */
   subscribe(onStateChange?: StateObserver): () => void;
 
+  /** Evaluates a flag */
   evaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<Value.Widen<T>>;
 
+  /** Returns flag value for a given flag */
   getFlag<T extends Value>(path: string, defaultValue: T): Promise<Value.Widen<T>>;
 }

--- a/packages/sdk/src/trackers/pageViews.ts
+++ b/packages/sdk/src/trackers/pageViews.ts
@@ -2,6 +2,10 @@ import { Closer } from '../Closer';
 import { Trackable } from '../Trackable';
 import { listenOn, spyOn } from '../utils';
 
+/**
+ * Tracks page views
+ * @public
+ */
 export function pageViews(): Trackable.Manager {
   return controller => {
     let referrer: string = document.referrer;

--- a/packages/sdk/src/trackers/visitorId.ts
+++ b/packages/sdk/src/trackers/visitorId.ts
@@ -3,6 +3,9 @@ import { uuid, Cookie } from '../utils';
 
 const COOKIE_NAME = 'cnfdVisitorId';
 
+/**
+ * Visitor Identity which can be used in Cookies
+ * @public  */
 export const visitorIdentity = (): Trackable.Manager => controller => {
   if (typeof document === 'undefined') return;
   let value = Cookie.get(COOKIE_NAME);

--- a/packages/sdk/src/trackers/webVitals.ts
+++ b/packages/sdk/src/trackers/webVitals.ts
@@ -46,7 +46,7 @@ export type WebVitalsOptions = {
  * Emit {@link https://web.dev/articles/vitals | Web Vitals} metric events.
  *
  * @param options - specifying which metrics to emit
- * @returns a {@link Topic} to be used with {@link Confidence.track }
+ * @returns a Topic to be used with Confidence.track
  * @public
  */
 export function webVitals({

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -12,6 +12,7 @@ export function spyOn<T extends {}, N extends keyof PickFn<T>>(
 ): CleanupFn {
   const t = target as any;
   const originalFn = t[fnName];
+  // eslint-disable-next-line func-names
   t[fnName] = function (...args: any): any {
     try {
       return originalFn.call(this, ...args);


### PR DESCRIPTION
This PR is adding documentation placeholders that resolve most of the issues in the generated API reports.
