### PR TITLE
ci: remove trigger of amend release

### DIFF
--- a/.github/workflows/Release-Please.yml
+++ b/.github/workflows/Release-Please.yml
@@ -23,14 +23,6 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
           default-branch: main
           monorepo-tags: true
-      - name: Trigger Amend Release Workflow
-        if: ${{ ! steps.release.outputs.releases_created }}
-        run: |
-          curl -X POST \
-          -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          https://api.github.com/repos/spotify/confidence-sdk-js/dispatches \
-          -d '{"event_type":"release_amend_trigger", "client_payload": {}}'
 
   Build-And-Publish:
     environment: deployment


### PR DESCRIPTION
Currently the amending of the release please PR seems to do more harm than good.
