### PR TITLE
chore!: revert dependencies

### DIFF
--- a/packages/openfeature-server-provider/package.json
+++ b/packages/openfeature-server-provider/package.json
@@ -8,12 +8,12 @@
     "@microsoft/api-extractor": "7.43.1",
     "@openfeature/core": "^1.1.0",
     "@openfeature/server-sdk": "^1.13.5",
-    "@spotify-confidence/sdk": "0.1.5",
+    "@spotify-confidence/sdk": "0.1.4",
     "rollup": "4.14.2"
   },
   "peerDependencies": {
     "@openfeature/server-sdk": "^1.13.5",
-    "@spotify-confidence/sdk": "^0.1.5"
+    "@spotify-confidence/sdk": "^0.1.4"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/openfeature-web-provider/package.json
+++ b/packages/openfeature-web-provider/package.json
@@ -11,12 +11,12 @@
     "@microsoft/api-extractor": "7.43.1",
     "@openfeature/core": "^1.1.0",
     "@openfeature/web-sdk": "^1.0.3",
-    "@spotify-confidence/sdk": "0.1.5",
+    "@spotify-confidence/sdk": "0.1.4",
     "rollup": "4.14.2"
   },
   "peerDependencies": {
     "@openfeature/web-sdk": "^1.0.3",
-    "@spotify-confidence/sdk": "^0.1.5"
+    "@spotify-confidence/sdk": "^0.1.4"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3618,11 +3618,11 @@ __metadata:
     "@microsoft/api-extractor": "npm:7.43.1"
     "@openfeature/core": "npm:^1.1.0"
     "@openfeature/server-sdk": "npm:^1.13.5"
-    "@spotify-confidence/sdk": "npm:0.1.5"
+    "@spotify-confidence/sdk": "npm:0.1.4"
     rollup: "npm:4.14.2"
   peerDependencies:
     "@openfeature/server-sdk": ^1.13.5
-    "@spotify-confidence/sdk": ^0.1.5
+    "@spotify-confidence/sdk": ^0.1.4
   languageName: unknown
   linkType: soft
 
@@ -3633,12 +3633,12 @@ __metadata:
     "@microsoft/api-extractor": "npm:7.43.1"
     "@openfeature/core": "npm:^1.1.0"
     "@openfeature/web-sdk": "npm:^1.0.3"
-    "@spotify-confidence/sdk": "npm:0.1.5"
+    "@spotify-confidence/sdk": "npm:0.1.4"
     fast-deep-equal: "npm:^3.1.3"
     rollup: "npm:4.14.2"
   peerDependencies:
     "@openfeature/web-sdk": ^1.0.3
-    "@spotify-confidence/sdk": ^0.1.5
+    "@spotify-confidence/sdk": ^0.1.4
   languageName: unknown
   linkType: soft
 
@@ -3655,6 +3655,15 @@ __metadata:
     react: ^18.2.0
   languageName: unknown
   linkType: soft
+
+"@spotify-confidence/sdk@npm:0.1.4":
+  version: 0.1.4
+  resolution: "@spotify-confidence/sdk@npm:0.1.4"
+  dependencies:
+    web-vitals: "npm:^3.5.2"
+  checksum: 10c0/a77c3e051a6378641125fc890559d29e36639490b05df00b266a480a0bd90022a5aabca0a6c555035ae3f2d53d5da1afe6bbb0536b6b229ab652e1765885e452
+  languageName: node
+  linkType: hard
 
 "@spotify-confidence/sdk@npm:0.1.5, @spotify-confidence/sdk@workspace:, @spotify-confidence/sdk@workspace:packages/sdk":
   version: 0.0.0-use.local


### PR DESCRIPTION
This PR reverts the dependency upgrading as the issue of having to upgrade all dependencies across the workplace has been fixed.