### PR TITLE
chore: revert broken version bump

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
-  "packages/openfeature-server-provider": "0.2.10",
-  "packages/openfeature-web-provider": "0.2.10",
-  "packages/sdk": "0.1.5",
-  "packages/react": "0.0.5"
+  "packages/openfeature-server-provider": "0.2.9",
+  "packages/openfeature-web-provider": "0.2.9",
+  "packages/sdk": "0.1.4",
+  "packages/react": "0.0.4"
 }

--- a/packages/openfeature-server-provider/CHANGELOG.md
+++ b/packages/openfeature-server-provider/CHANGELOG.md
@@ -12,12 +12,6 @@
   * dependencies
     * @spotify-confidence/sdk bumped from 0.0.2 to 0.0.3
 
-### Dependencies
-
-* The following workspace dependencies were updated
-  * devDependencies
-    * @spotify-confidence/sdk bumped from 0.1.4 to 0.1.5
-
 ## [0.2.9](https://github.com/spotify/confidence-sdk-js/compare/openfeature-server-provider-v0.2.8...openfeature-server-provider-v0.2.9) (2024-06-07)
 
 

--- a/packages/openfeature-server-provider/package.json
+++ b/packages/openfeature-server-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spotify-confidence/openfeature-server-provider",
   "license": "Apache-2.0",
-  "version": "0.2.10",
+  "version": "0.2.9",
   "type": "module",
   "types": "build/types/index.d.ts",
   "devDependencies": {

--- a/packages/openfeature-web-provider/CHANGELOG.md
+++ b/packages/openfeature-web-provider/CHANGELOG.md
@@ -6,12 +6,6 @@
   * dependencies
     * @spotify-confidence/client-http bumped from ^0.1.2 to ^0.1.3
 
-### Dependencies
-
-* The following workspace dependencies were updated
-  * devDependencies
-    * @spotify-confidence/sdk bumped from 0.1.4 to 0.1.5
-
 ## [0.2.9](https://github.com/spotify/confidence-sdk-js/compare/openfeature-web-provider-v0.2.8...openfeature-web-provider-v0.2.9) (2024-06-07)
 
 

--- a/packages/openfeature-web-provider/package.json
+++ b/packages/openfeature-web-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spotify-confidence/openfeature-web-provider",
   "license": "Apache-2.0",
-  "version": "0.2.10",
+  "version": "0.2.9",
   "type": "module",
   "types": "build/types/index.d.ts",
   "dependencies": {

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -6,20 +6,6 @@
   * devDependencies
     * @spotify-confidence/sdk bumped from 0.1.3 to 0.1.4
 
-## [0.0.5](https://github.com/spotify/confidence-sdk-js/compare/react-v0.0.4...react-v0.0.5) (2024-07-08)
-
-
-### ✨ New Features
-
-* improved suspense management ([#167](https://github.com/spotify/confidence-sdk-js/issues/167)) ([0a96d8f](https://github.com/spotify/confidence-sdk-js/commit/0a96d8f8d6ea25a13c1ecdf2f5a1598e53e9c1fc))
-
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * devDependencies
-    * @spotify-confidence/sdk bumped from 0.1.4 to 0.1.5
-
 ## [0.0.3](https://github.com/spotify/confidence-sdk-js/compare/react-v0.0.2...react-v0.0.3) (2024-06-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spotify-confidence/react",
   "license": "Apache-2.0",
-  "version": "0.0.5",
+  "version": "0.0.4",
   "types": "build/types/index.d.ts",
   "files": [
     "dist/index.*"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,12 +22,12 @@
     "main": "dist/index.js"
   },
   "peerDependencies": {
-    "@spotify-confidence/sdk": "^0.1.5",
+    "@spotify-confidence/sdk": "^0.1.4",
     "react": "^18.2.0"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "7.43.1",
-    "@spotify-confidence/sdk": "0.1.5",
+    "@spotify-confidence/sdk": "0.1.4",
     "react": "^18.2.0",
     "rollup": "4.14.2"
   },

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Changelog
 
-## [0.1.5](https://github.com/spotify/confidence-sdk-js/compare/sdk-v0.1.4...sdk-v0.1.5) (2024-07-08)
-
-
-### 🐛 Bug Fixes
-
-* infinite in memory flag cache ([#170](https://github.com/spotify/confidence-sdk-js/issues/170)) ([9156dd7](https://github.com/spotify/confidence-sdk-js/commit/9156dd70942f295c4f45125137c022526b15ffdb))
-* shared requests aborted ([#169](https://github.com/spotify/confidence-sdk-js/issues/169)) ([9dc6314](https://github.com/spotify/confidence-sdk-js/commit/9dc6314fab1028af940a672adc5811ec35c570ea))
-
 ## [0.1.4](https://github.com/spotify/confidence-sdk-js/compare/sdk-v0.1.3...sdk-v0.1.4) (2024-06-05)
 
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spotify-confidence/sdk",
   "license": "Apache-2.0",
-  "version": "0.1.5",
+  "version": "0.1.4",
   "types": "build/types/index.d.ts",
   "engineStrict": true,
   "engines": {

--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -326,7 +326,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
   }: ConfidenceOptions): Confidence {
     const sdk = {
       id: SdkId.SDK_ID_JS_CONFIDENCE,
-      version: '0.1.5', // x-release-please-version
+      version: '0.1.4', // x-release-please-version
     } as const;
     let flagResolverClient: FlagResolverClient = new FetchingFlagResolverClient({
       clientSecret,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3656,16 +3656,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@spotify-confidence/sdk@npm:0.1.4":
-  version: 0.1.4
-  resolution: "@spotify-confidence/sdk@npm:0.1.4"
-  dependencies:
-    web-vitals: "npm:^3.5.2"
-  checksum: 10c0/a77c3e051a6378641125fc890559d29e36639490b05df00b266a480a0bd90022a5aabca0a6c555035ae3f2d53d5da1afe6bbb0536b6b229ab652e1765885e452
-  languageName: node
-  linkType: hard
-
-"@spotify-confidence/sdk@workspace:, @spotify-confidence/sdk@workspace:packages/sdk":
+"@spotify-confidence/sdk@npm:0.1.4, @spotify-confidence/sdk@workspace:, @spotify-confidence/sdk@workspace:packages/sdk":
   version: 0.0.0-use.local
   resolution: "@spotify-confidence/sdk@workspace:packages/sdk"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3647,11 +3647,11 @@ __metadata:
   resolution: "@spotify-confidence/react@workspace:packages/react"
   dependencies:
     "@microsoft/api-extractor": "npm:7.43.1"
-    "@spotify-confidence/sdk": "npm:0.1.5"
+    "@spotify-confidence/sdk": "npm:0.1.4"
     react: "npm:^18.2.0"
     rollup: "npm:4.14.2"
   peerDependencies:
-    "@spotify-confidence/sdk": ^0.1.5
+    "@spotify-confidence/sdk": ^0.1.4
     react: ^18.2.0
   languageName: unknown
   linkType: soft
@@ -3665,7 +3665,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@spotify-confidence/sdk@npm:0.1.5, @spotify-confidence/sdk@workspace:, @spotify-confidence/sdk@workspace:packages/sdk":
+"@spotify-confidence/sdk@workspace:, @spotify-confidence/sdk@workspace:packages/sdk":
   version: 0.0.0-use.local
   resolution: "@spotify-confidence/sdk@workspace:packages/sdk"
   dependencies:


### PR DESCRIPTION
This restores the repo to the state before the broken July 12th release.

If we choose to go this route we would also need to manually remove the tags before merging the release please PR.

I triggered a release please PR on top of this here: https://github.com/spotify/confidence-sdk-js/pull/186