### PR TITLE
fix!: mark Confidence constructor as internal

### DIFF
--- a/api/sdk.api.md
+++ b/api/sdk.api.md
@@ -14,6 +14,7 @@ export type Closer = () => void;
 
 // @public
 export class Confidence implements EventSender, Trackable, FlagResolver {
+    // @internal
     constructor(config: Configuration, parent?: Confidence);
     clearContext(): void;
     readonly config: Configuration;

--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -80,6 +80,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
 
   private readonly flagStateSubject: Subscribe<State>;
 
+  /** @internal */
   constructor(config: Configuration, parent?: Confidence) {
     this.config = config;
     this.parent = parent;


### PR DESCRIPTION
We don't want our users to use the Confidence constructor but rather the `create()` method.

Note: This should be considered a breaking change.