### PR TITLE
fix!: visitor id disabled by default

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -75,6 +75,20 @@ confidence.track('event_name', { 'message-detail1': 'something interesting' });
 ### Auto track
 
 Confidence supports automatically tracking certain things out of the box and supports API's for you to extend that functionality.
+
+#### Visitor ID (web)
+
+Confidence can provide all flag resolves and tracking events with a browser specific identifier. We call this `visitor_id`.  
+The `visitor_id` is stored in a cookie. To add a generated `visitor_id` to the context, use the following:
+
+```ts
+import { visitorIdentity } from './trackers';
+confidence.track(visitorIdentity());
+```
+
+#### Page Views (web)
+
+Confidence can automatically track `page views` on events such as `load`, `pushState`, `replaceState`, `popstate` and `hashchange`.
 To automatically track `page views`, use the following:
 
 ```ts
@@ -82,7 +96,9 @@ import { Confidence, pageViews } from '@spotify-confidence/sdk';
 confidence.track(pageViews());
 ```
 
-and to automatically track events containing web vitals data, use:
+#### Web vitals (web)
+
+To automatically send tracking events containing [web vitals data](https://web.dev/articles/vitals), use:
 
 ```ts
 import { Confidence, webVitals } from '@spotify-confidence/sdk';

--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -11,7 +11,6 @@ import { Context } from './context';
 import { Logger } from './logger';
 import { FlagEvaluation, FlagResolver, State, StateObserver } from './flags';
 import { SdkId } from './generated/confidence/flags/resolver/v1/types';
-import { visitorIdentity } from './trackers';
 import { Trackable } from './Trackable';
 import { Closer } from './Closer';
 import { Subscribe, Observer, subject, changeObserver } from './observing';
@@ -366,17 +365,13 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
       maxOpenRequests: (50 * 1024) / (estEventSizeKb * maxBatchSize),
       logger,
     });
-    const root = new Confidence({
+    return new Confidence({
       environment: environment,
       flagResolverClient,
       eventSenderEngine,
       timeout,
       logger,
     });
-    if (environment === 'client') {
-      root.track(visitorIdentity());
-    }
-    return root;
   }
 }
 


### PR DESCRIPTION
We want to allow users to opt out from `visitor_id` which is a feature that uses cookies as a storage medium.
Since we are defaulting to disable visitor id (whereas it was previously enabled), we mark the commit as breaking.
