### PR TITLE
fix: react-native runtime incompatibilities

### DIFF
--- a/packages/sdk/src/FlagResolverClient.ts
+++ b/packages/sdk/src/FlagResolverClient.ts
@@ -292,7 +292,7 @@ export function withRequestLogic(fetchImplementation: (request: Request) => Prom
     // update send-time before sending
     .modifyRequest(async request => {
       if (request.method === 'POST') {
-        const body = JSON.stringify({ ...(await request.json()), sendTime: new Date().toISOString() });
+        const body = JSON.stringify({ ...(await request.clone().json()), sendTime: new Date().toISOString() });
         return new Request(request, { body });
       }
       return request;

--- a/packages/sdk/src/fetch-util.ts
+++ b/packages/sdk/src/fetch-util.ts
@@ -233,7 +233,7 @@ export class FetchBuilder {
       let retryCount = 0;
 
       const doRetry = async (e: unknown): Promise<Response> => {
-        request.signal?.throwIfAborted();
+        if (request.signal?.aborted ?? false) throw new Error('Request aborted');
         // if there are no more attempts we throw the last error
         if (retryCount >= maxRetries) throw e;
 


### PR DESCRIPTION
This PR fixes two react-native compatibility issues with the iOS runtime:

- AbortSignal.throwIfAborted is not supported
- It's more picky with creating new Requests. More specifically, even if overriding the body of a request, you can't use an already consumed request as the template.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing
- [ ] Relevant documentation updated
- [ ] linter/style run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app
