### PR TITLE
fix: hanging resolve bug

### DIFF
--- a/packages/sdk/src/FlagResolution.ts
+++ b/packages/sdk/src/FlagResolution.ts
@@ -114,7 +114,7 @@ export class ReadyFlagResolution implements FlagResolution {
 
 ReadyFlagResolution.prototype.state = 'READY';
 
-class FailedFlagResolution implements FlagResolution {
+export class FailedFlagResolution implements FlagResolution {
   declare state: 'ERROR';
   constructor(readonly context: Value.Struct, readonly code: FlagEvaluation.ErrorCode, readonly message: string) {}
 

--- a/packages/sdk/src/FlagResolverClient.test.ts
+++ b/packages/sdk/src/FlagResolverClient.test.ts
@@ -275,6 +275,12 @@ describe('Backend environment Evaluation', () => {
     resolveHandlerMock.mockRejectedValue(new Error('Test error'));
     const flagResolution = await instanceUnderTest.resolve({}, ['testflag']);
     expect(flagResolution).toBeInstanceOf(FailedFlagResolution);
+    expect(flagResolution.evaluate('testflag', {})).toEqual({
+      errorCode: 'GENERAL',
+      errorMessage: '500: Test error',
+      reason: 'ERROR',
+      value: {},
+    });
   });
 });
 

--- a/packages/sdk/src/FlagResolverClient.ts
+++ b/packages/sdk/src/FlagResolverClient.ts
@@ -157,8 +157,9 @@ export class FetchingFlagResolverClient implements FlagResolverClient {
         .catch(error => {
           if (error instanceof ResolveError) {
             return FlagResolution.failed(context, error.code, error.message);
+          } else {
+            return FlagResolution.failed(context, 'GENERAL', error.message);
           }
-          throw error;
         })
         .finally(() => {
           this.markLatency(Date.now() - start);


### PR DESCRIPTION
We make sure that the `resolve` function always returns a `FlagResolution` and does not throw.

