### PR TITLE
feat: configurable apply debounce

### DIFF
--- a/api/sdk.api.md
+++ b/api/sdk.api.md
@@ -22,7 +22,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     //
     // @internal
     readonly contextChanges: Subscribe<string[]>;
-    static create({ clientSecret, region, timeout, environment, fetchImplementation, logger, resolveBaseUrl, disableTelemetry, }: ConfidenceOptions): Confidence;
+    static create({ clientSecret, region, timeout, environment, fetchImplementation, logger, resolveBaseUrl, disableTelemetry, applyDebounce, }: ConfidenceOptions): Confidence;
     get environment(): string;
     evaluateFlag(path: string, defaultValue: string): FlagEvaluation<string>;
     // (undocumented)
@@ -51,6 +51,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
 
 // @public
 export interface ConfidenceOptions {
+    applyDebounce?: number;
     clientSecret: string;
     disableTelemetry?: boolean;
     environment: 'client' | 'backend';

--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -40,6 +40,8 @@ export interface ConfidenceOptions {
   resolveBaseUrl?: string;
   /** Disable telemetry */
   disableTelemetry?: boolean;
+  /** Allows you to debounce the apply message. Set in ms. 0 is treated as synchronous */
+  applyDebounce?: number;
 }
 
 /**
@@ -348,6 +350,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     logger = defaultLogger(),
     resolveBaseUrl,
     disableTelemetry = false,
+    applyDebounce = 10,
   }: ConfidenceOptions): Confidence {
     const sdk = {
       id: SdkId.SDK_ID_JS_CONFIDENCE,
@@ -367,6 +370,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
       region,
       resolveBaseUrl,
       telemetry,
+      applyDebounce: applyDebounce,
     });
     if (environment === 'client') {
       flagResolverClient = new CachingFlagResolverClient(flagResolverClient, Number.POSITIVE_INFINITY);

--- a/packages/sdk/src/FlagResolverClient.test.ts
+++ b/packages/sdk/src/FlagResolverClient.test.ts
@@ -62,7 +62,7 @@ describe('Client environment Evaluation', () => {
     instanceUnderTest = new FetchingFlagResolverClient({
       fetchImplementation,
       clientSecret: 'secret',
-      applyTimeout: 10,
+      applyDebounce: 10,
       sdk: {
         id: SdkId.SDK_ID_JS_CONFIDENCE,
         version: 'test',
@@ -139,6 +139,7 @@ describe('Backend environment Evaluation', () => {
     },
     environment: 'backend',
     resolveTimeout: 10,
+    applyDebounce: 0,
     telemetry: new Telemetry({ disabled: true, logger: { warn: jest.fn() }, environment: 'backend' }),
   });
 

--- a/packages/sdk/src/FlagResolverClient.ts
+++ b/packages/sdk/src/FlagResolverClient.ts
@@ -22,10 +22,7 @@ import { SimpleFetch } from './types';
 const FLAG_PREFIX = 'flags/';
 
 export class ResolveError extends Error {
-  constructor(
-    public readonly code: FlagEvaluation.ErrorCode,
-    message: string,
-  ) {
+  constructor(public readonly code: FlagEvaluation.ErrorCode, message: string) {
     super(message);
   }
 }


### PR DESCRIPTION
Making apply debounce (previously named timeout) configurable from the outside (when creating Confidence instance).
Also making sure that setting the applyDebounce to 0 the apply function is called synchronously (or without `setTimeout`).