### PR TITLE
fix: create a safe environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ import { Confidence } from '@spotify-confidence/sdk';
 const confidence = Confidence.create({
   clientSecret: 'mysecret',
   region: 'eu', // or 'us'
-  environment: 'client', // or 'server'
+  environment: 'client', // or 'backend'
   timeout: 1000,
 });
 ```

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -24,7 +24,7 @@ import { Confidence } from '@spotify-confidence/sdk';
 const confidence = Confidence.create({
   clientSecret: 'mysecret',
   region: 'eu',
-  environment: 'client',
+  environment: 'client', // or 'backend'
   timeout: 1000,
 });
 ```

--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -358,6 +358,9 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     applyDebounce = 10,
     waitUntil,
   }: ConfidenceOptions): Confidence {
+    if (environment !== 'client' && environment !== 'backend') {
+      throw new Error(`Invalid environment: ${environment}. Must be 'client' or 'backend'.`);
+    }
     const sdk = {
       id: SdkId.SDK_ID_JS_CONFIDENCE,
       version: '0.2.4', // x-release-please-version


### PR DESCRIPTION
Fix the documentation so that it does not trick people and validate the string passed to the environment.