### PR TITLE
fix: make telemetry Logger optional (and don't pass it)

### DIFF
--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -367,7 +367,6 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     } as const;
     const telemetry = new Telemetry({
       disabled: disableTelemetry,
-      logger,
       environment,
     });
     let flagResolverClient: FlagResolverClient = new FetchingFlagResolverClient({

--- a/packages/sdk/src/Telemetry.test.ts
+++ b/packages/sdk/src/Telemetry.test.ts
@@ -3,7 +3,7 @@ import { Telemetry } from './Telemetry';
 
 describe('Telemetry', () => {
   it('registerCounter and increment counter', () => {
-    const telemetry = new Telemetry({ disabled: false, logger: {}, environment: 'backend' });
+    const telemetry = new Telemetry({ disabled: false, environment: 'backend' });
     const counter = telemetry.registerCounter({
       library: LibraryTraces_Library.LIBRARY_CONFIDENCE,
       version: '9.9.9',
@@ -26,7 +26,7 @@ describe('Telemetry', () => {
   });
 
   it('registerMeter and add measurement', () => {
-    const telemetry = new Telemetry({ disabled: false, logger: {}, environment: 'client' });
+    const telemetry = new Telemetry({ disabled: false, environment: 'client' });
     const meter = telemetry.registerMeter({
       library: LibraryTraces_Library.LIBRARY_CONFIDENCE,
       version: '9.9.9',
@@ -49,7 +49,7 @@ describe('Telemetry', () => {
   });
 
   it('snapshot is empty when telemetry is disabled', () => {
-    const telemetry = new Telemetry({ disabled: true, logger: {}, environment: 'client' });
+    const telemetry = new Telemetry({ disabled: true, environment: 'client' });
     const counter = telemetry.registerCounter({
       library: LibraryTraces_Library.LIBRARY_CONFIDENCE,
       version: '9.9.9',
@@ -61,7 +61,7 @@ describe('Telemetry', () => {
   });
 
   it('monitoring gets cleared after snapshot is obtained', () => {
-    const telemetry = new Telemetry({ disabled: false, logger: {}, environment: 'client' });
+    const telemetry = new Telemetry({ disabled: false, environment: 'client' });
     const counter = telemetry.registerCounter({
       library: LibraryTraces_Library.LIBRARY_CONFIDENCE,
       version: '9.9.9',

--- a/packages/sdk/src/Telemetry.ts
+++ b/packages/sdk/src/Telemetry.ts
@@ -8,7 +8,7 @@ import {
 } from './generated/confidence/telemetry/v1/telemetry';
 import { Logger } from './logger';
 
-export type TelemetryOptions = { disabled: boolean; logger: Logger; environment: 'backend' | 'client' };
+export type TelemetryOptions = { disabled: boolean; logger?: Logger; environment: 'backend' | 'client' };
 
 export type Tag = {
   library: LibraryTraces_Library;
@@ -21,7 +21,7 @@ export type Meter = (value: number) => void;
 export type TraceConsumer = (trace: Omit<LibraryTraces_Trace, 'id'>) => void;
 export class Telemetry {
   private readonly disabled: boolean;
-  private readonly logger: Logger;
+  private readonly logger?: Logger;
   private readonly libraryTraces: LibraryTraces[] = [];
   private readonly platform: Platform;
 
@@ -42,7 +42,7 @@ export class Telemetry {
       traces,
     });
     return data => {
-      this.logger.debug?.(LibraryTraces_TraceId[id], data);
+      this.logger?.debug?.(LibraryTraces_TraceId[id], data);
       traces.push({
         id,
         ...data,


### PR DESCRIPTION
I grew tired of the telemetry outputs and made it optional and stopped passing it.