### PR TITLE
fix: avoid cloning requests in FetchBuilder

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,7 @@
     "es/no-optional-chaining": "off",
     "es/no-nullish-coalescing-operators": "off",
     "no-inner-declarations": "off",
-    "@typescript-eslint/no-use-before-define": "off"
+    "@typescript-eslint/no-use-before-define": "off",
+    "no-param-reassign": "off"
   }
 }

--- a/api/sdk.api.md
+++ b/api/sdk.api.md
@@ -157,7 +157,7 @@ export function pageViews(): Trackable.Manager;
 
 // Warning: (ae-missing-release-tag) "SimpleFetch" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export type SimpleFetch = (request: Request) => Promise<Response>;
 
 // @public

--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -14,10 +14,11 @@ import { SdkId } from './generated/confidence/flags/resolver/v1/types';
 import { Trackable } from './Trackable';
 import { Closer } from './Closer';
 import { Subscribe, Observer, subject, changeObserver } from './observing';
-import { SimpleFetch, WaitUntil } from './types';
+import { WaitUntil } from './types';
 import { FlagResolution } from './FlagResolution';
 import { AccessiblePromise } from './AccessiblePromise';
 import { Telemetry } from './Telemetry';
+import { SimpleFetch } from './fetch-util';
 
 /**
  * Confidence options, to be used for easier initialization of Confidence

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -7,3 +7,4 @@ export * from './trackers';
 export * from './Trackable';
 export * from './Closer';
 export * from './types';
+export { SimpleFetch } from './fetch-util';

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,2 +1,1 @@
-export type SimpleFetch = (request: Request) => Promise<Response>;
 export type WaitUntil = (promise: Promise<void>) => void;


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

Minimal fix to circumvent the [this](https://github.com/nodejs/undici/issues/4068) bug in node which looses AbortSignals on cloned requests which in turn makes our retries infinite. The idea of the fix is to avoid creating requests in FetchBuilder until the very last step just before sending the request.

fixes #221 

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing
- [ ] Relevant documentation updated
- [ ] linter/style run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app
