### PR TITLE
fix: include correct dist files

### DIFF
--- a/packages/openfeature-server-provider/package.json
+++ b/packages/openfeature-server-provider/package.json
@@ -20,7 +20,7 @@
     "clean": "rm -rf {build,dist}"
   },
   "files": [
-    "dist/index.*"
+    "dist/*"
   ],
   "type": "module",
   "publishConfig": {

--- a/packages/openfeature-web-provider/package.json
+++ b/packages/openfeature-web-provider/package.json
@@ -23,7 +23,7 @@
     "clean": "rm -rf {build,dist}"
   },
   "files": [
-    "dist/index.*"
+    "dist/*"
   ],
   "type": "module",
   "publishConfig": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,7 +3,7 @@
   "license": "Apache-2.0",
   "version": "0.0.13",
   "files": [
-    "dist/index.*"
+    "dist/*"
   ],
   "scripts": {
     "bundle": "rollup -c && ../../validate-api.sh",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -18,7 +18,7 @@
     "web-vitals": "^3.5.2"
   },
   "files": [
-    "dist/index.*"
+    "dist/*"
   ],
   "devDependencies": {
     "@microsoft/api-extractor": "7.43.1",

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -62,7 +62,7 @@ module.exports = defineConfig({
         workspace.set('scripts.bundle', 'rollup -c && ../../validate-api.sh');
       }
 
-      workspace.set('files', ['dist/index.*']);
+      workspace.set('files', ['dist/*']);
       workspace.set('scripts.build', 'tsc');
       workspace.set('scripts.clean', 'rm -rf {build,dist}');
       workspace.set('scripts.prepack', 'yarn build && yarn bundle');


### PR DESCRIPTION
The `pack` for the react package did not include the `/client/*` and `/server/*`. We decided to just go with the full contents of the dist.