### PR TITLE
feat(react): react server support

### DIFF
--- a/api/react-server.d.ts
+++ b/api/react-server.d.ts
@@ -1,0 +1,9 @@
+import { Confidence } from '@spotify-confidence/sdk';
+import React, { ReactNode } from 'react';
+
+declare function ConfidenceProvider(props: {
+    confidence: Confidence;
+    children?: ReactNode;
+}): Promise<React.JSX.Element>;
+
+export { ConfidenceProvider };

--- a/api/react.d.ts
+++ b/api/react.d.ts
@@ -1,86 +1,21 @@
-import { EventSender, Trackable, FlagResolver, Confidence, Configuration, Value, Closer, Context, StateObserver, FlagEvaluation } from '@spotify-confidence/sdk';
-import { FC, PropsWithChildren } from 'react';
+import { ConfidenceOptions, Confidence, Context, FlagEvaluation, Value } from '@spotify-confidence/sdk';
+import { FC, PropsWithChildren, FunctionComponent, ReactNode } from 'react';
 
-/**
- * Confidence React instance
- * @public
- */
-declare class ConfidenceReact implements EventSender, Trackable, FlagResolver {
-    /**
-     * Confidence Delegate
-     *  @internal */
-    readonly delegate: Confidence;
-    constructor(delegate: Confidence);
-    /** Return configurations of the Confidence instance */
-    get config(): Configuration;
-    /**
-     * Current serialized Context
-     * @internal */
-    get contextState(): string;
-    /**
-     * Tracks an event
-     * @param name - event name
-     * @param message - data to track */
-    track(name: string, message?: Value.Struct): void;
-    /**
-     * Tracks an event
-     * @param manager - trackable manager */
-    track(manager: Trackable.Manager): Closer;
-    /** Returns context of the current Confidence instance */
-    getContext(): Context;
-    /** Set Confidence context */
-    setContext(context: Context, { transition }?: {
-        transition?: boolean | undefined;
-    }): void;
-    /** Subscribe to flag changes in Confidence */
-    subscribe(onStateChange?: StateObserver | undefined): () => void;
-    /** Clears context of current Confidence instance */
-    clearContext({ transition }?: {
-        transition?: boolean | undefined;
-    }): void;
-    /**
-     * Creates a new ConfidenceReact instance with context
-     * @param context - Confidence context
-     * @returns ConfidenceReact instance
-     */
-    withContext(context: Context): ConfidenceReact;
-    /** Evaluates a flag */
-    evaluateFlag(path: string, defaultValue: string): FlagEvaluation<string>;
-    evaluateFlag(path: string, defaultValue: boolean): FlagEvaluation<boolean>;
-    evaluateFlag(path: string, defaultValue: number): FlagEvaluation<number>;
-    evaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<T>;
-    /** Returns flag value for a given flag */
-    getFlag(path: string, defaultValue: string): Promise<string>;
-    getFlag(path: string, defaultValue: boolean): Promise<boolean>;
-    getFlag(path: string, defaultValue: number): Promise<number>;
-    getFlag<T extends Value>(path: string, defaultValue: T): Promise<T>;
-    /** Hook to access Context */
-    useContext(): Context;
-    /** Hook to access the WithContext functionality. Returns a  ConfidenceReact instance with the passed context. */
-    useWithContext(context: Context): ConfidenceReact;
-    /** Hook to use EvaluateFlag functionality */
-    useEvaluateFlag(path: string, defaultValue: string): FlagEvaluation<string>;
-    useEvaluateFlag(path: string, defaultValue: number): FlagEvaluation<number>;
-    useEvaluateFlag(path: string, defaultValue: boolean): FlagEvaluation<boolean>;
-    useEvaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<T>;
-    /** Hook to use getFlag functionality */
-    useFlag(path: string, defaultValue: string): string;
-    useFlag(path: string, defaultValue: number): number;
-    useFlag(path: string, defaultValue: boolean): boolean;
-    useFlag<T extends Value>(path: string, defaultValue: T): T;
-    private assertContext;
-}
+declare const ManagedConfidenceProvider: FC<PropsWithChildren<{
+    options: ConfidenceOptions;
+}>>;
 /**
  * Confidence Provider for React
  * @public
  */
-type ConfidenceProvider = FC<PropsWithChildren<{
+interface ConfidenceProvider extends FunctionComponent<{
     confidence: Confidence;
-}>> & {
+    children?: ReactNode;
+}> {
     WithContext: FC<PropsWithChildren<{
         context: Context;
     }>>;
-};
+}
 /**
  * Confidence Provider for React
  * @public
@@ -90,31 +25,31 @@ declare const ConfidenceProvider: ConfidenceProvider;
  * Enables using Confidence
  * @public
  */
-declare const useConfidence: () => ConfidenceReact;
+declare const useConfidence: () => Confidence;
 /**
  * Use with given Confidence Context
  * @public
  */
-declare function useWithContext(context: Context, parent?: ConfidenceReact): ConfidenceReact;
+declare function useWithContext(context: Context, parent?: Confidence): Confidence;
 /**
  * Use Confidence Context
  * @public
  */
-declare function useConfidenceContext(confidence?: ConfidenceReact): Context;
+declare function useConfidenceContext(confidence?: Confidence): Context;
 /**
  * Use EvaluateFlag
  * @public */
-declare function useEvaluateFlag(path: string, defaultValue: string, confidence?: ConfidenceReact): FlagEvaluation<string>;
-declare function useEvaluateFlag(path: string, defaultValue: number, confidence?: ConfidenceReact): FlagEvaluation<number>;
-declare function useEvaluateFlag(path: string, defaultValue: boolean, confidence?: ConfidenceReact): FlagEvaluation<boolean>;
-declare function useEvaluateFlag<T extends Value>(path: string, defaultValue: T, confidence?: ConfidenceReact): FlagEvaluation<T>;
+declare function useEvaluateFlag(path: string, defaultValue: string, confidence?: Confidence): FlagEvaluation<string>;
+declare function useEvaluateFlag(path: string, defaultValue: number, confidence?: Confidence): FlagEvaluation<number>;
+declare function useEvaluateFlag(path: string, defaultValue: boolean, confidence?: Confidence): FlagEvaluation<boolean>;
+declare function useEvaluateFlag<T extends Value>(path: string, defaultValue: T, confidence?: Confidence): FlagEvaluation<T>;
 /**
  * Use Flag
  * @public
  */
-declare function useFlag(path: string, defaultValue: string, confidence?: ConfidenceReact): string;
-declare function useFlag(path: string, defaultValue: number, confidence?: ConfidenceReact): number;
-declare function useFlag(path: string, defaultValue: boolean, confidence?: ConfidenceReact): boolean;
-declare function useFlag<T extends Value>(path: string, defaultValue: T, confidence?: ConfidenceReact): T;
+declare function useFlag(path: string, defaultValue: string, confidence?: Confidence): string;
+declare function useFlag(path: string, defaultValue: number, confidence?: Confidence): number;
+declare function useFlag(path: string, defaultValue: boolean, confidence?: Confidence): boolean;
+declare function useFlag<T extends Value>(path: string, defaultValue: T, confidence?: Confidence): T;
 
-export { ConfidenceProvider, ConfidenceReact, useConfidence, useConfidenceContext, useEvaluateFlag, useFlag, useWithContext };
+export { ConfidenceProvider, ManagedConfidenceProvider, useConfidence, useConfidenceContext, useEvaluateFlag, useFlag, useWithContext };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@spotify/tsconfig": "^15.0.0",
     "@swc/core": "^1.4.13",
     "@types/jest": "^29.5.3",
-    "@types/react": "^18.2.17",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "@yarnpkg/types": "^4.0.0",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -16,15 +16,17 @@ yarn add @spotify-confidence/react
 
 ### Initializing the ConfidenceProvider
 
-The Confidence React integration has a Provider that needs to be initialized. It accepts a Confidence instance and should wrap your component tree.
+The Confidence React integration has a Provider that needs to be initialized. It accepts a Confidence instance and should wrap your component tree. Here's an example for client-side rendering:
 
 ```ts
-import { Confidence } from '@spotify-confidence/sdk';
+import { Confidence } from '@spotify-confidence/sdk/';
+import { ConfidenceProvider } from '@spotify-confidence/sdk/react/client';
 
+// Client-side initialization
 const confidence = Confidence.create({
   clientSecret: 'mysecret',
   region: 'eu',
-  environment: 'client',
+  environment: 'client', // Note: For client-side rendering
   timeout: 1000,
 });
 
@@ -38,6 +40,8 @@ function App() {
   );
 }
 ```
+
+For server-side rendering setup, see the [Server-Side Rendering Support](#server-side-rendering-support) section below.
 
 Anywhere in the sub-tree under the `ConfidenceProvider` you can now access the confidence instance with the `useConfidence()` hook. The hook actually returns an instance of `ConfidenceReact` which is a wrapper around the normal `Confidence` API with some slight adaptations to integrate better with React. You can read more about the differences in the following sections.
 
@@ -65,6 +69,120 @@ Both of the flag hooks integrate with the React Suspense API so that the suspens
 The hooks are also reactive so that if the context changes, any components using the hooks will be re-rendered. As dependent components are re-rendered as soon as the context changes, one might expect that would again trigger the suspense boundary while the flag values are resolved. That is normally not the case however as the `ConfidenceReact.setContext` method is by default wrapped in a React [Transition](https://react.dev/reference/react/startTransition). If you would rather manage the transition logic yourself (with for example [React.useTransition()](https://react.dev/reference/react/useTransition)), or if you want to always trigger a suspense fallback to never show stale values, you can turn off the default behavior by calling `ConfidenceReact.setContext({...}, { transition:false })`.
 
 If the hooks can't resolve the flag values withing the timeout specified on the Confidence instance, they will instead return the default value.
+
+### Server-Side Rendering Support (experimental)
+
+The Confidence React SDK now supports server-side rendering (SSR) and React Server Components (RSC) for instance in Next.js. The SDK provides separate entry points for client and server components:
+
+- `@spotify-confidence/react/client` - For client components
+- `@spotify-confidence/react/server` - For server components
+
+When using the SDK in a server environment:
+
+1. Create a Confidence instance for server using the React.cache as the scope in CacheOptions.
+2. Provide an accessor for the Confidence instance using `withContext`.
+3. Use direct flag evaluation in server components.
+
+Here's an example of how to use Confidence in a Next.js application:
+
+```ts
+// app/confidence.ts (Server-side configuration)
+import { Confidence } from '@spotify-confidence/sdk';
+import React from 'react';
+
+const confidence = Confidence.create({
+  clientSecret: process.env.CONFIDENCE_CLIENT_SECRET!,
+  environment: 'backend',
+  timeout: 1000,
+  logger: console,
+  cache: {
+    scope: React.cache, // Use React.cache for server-side caching
+  },
+});
+
+// Confidence accessor for use in RSC.
+export const getConfidence = (context: Context): Confidence => {
+  return confidence.withContext(context);
+};
+
+// app/components/ServerComponent.tsx
+import { cookies } from 'next/headers';
+import { getConfidence } from '../confidence';
+
+export const ServerComponent = async () => {
+  const cookieStore = await cookies();
+  const targeting_key = cookieStore.get('cnfdVisitorId')?.value; // or a unique targeting value of your choice
+  const confidence = getConfidence({ targeting_key });
+
+  // Direct flag evaluation in server components
+  const color = await confidence.getFlag('my-feature-flag.color', 'blue');
+
+  return <div style={{ color }}>Server rendered content</div>;
+};
+```
+
+#### Server and Client
+
+If you also have interactive (client side) components that benefit from feature flagging support.
+Using the pattern below in addition to the above server side example will allow you to have the flag evaluations
+seamlessly transferred from the server component to the client components.
+
+Please note:
+
+- Server components use direct flag evaluation with `evaluateFlag` or `getFlag`
+- Client components use hooks (`useFlag`, `useConfidence`) for interactive features
+- Use React.cache for efficient server-side caching
+- The SDK automatically handles synchronization between server and client
+- Mutating the context in a client side component does not affect the server side confidence instance.
+
+```tsx
+// app/layout.tsx
+import { ConfidenceProvider } from '@spotify-confidence/react/server';
+import { getConfidence } from '../confidence';
+import { ClientComponent } from 'components/ClientComponent';
+import { ServerComponent } from 'components/ServerComponent';
+
+export default async function Layout() {
+  const cookieStore = await cookies();
+  const targeting_key = cookieStore.get('cnfdVisitorId')?.value;
+  const confidence = getConfidence({ targeting_key });
+
+  return (
+    <div>
+      <ConfidenceProvider confidence={confidence}>
+        <Suspense fallback={<h1>Loading...</h1>}>
+          <ClientComponent>
+            <ServerComponent>
+              <ClientComponent />
+            </ServerComponent>
+          </ClientComponent>
+        </Suspense>
+      </ConfidenceProvider>
+    </div>
+  );
+}
+
+// app/components/ClientComponent.tsx
+('use client');
+import { useConfidence, useFlag } from '@spotify-confidence/react/client';
+
+export const ClientComponent = () => {
+  // Use hooks in client components
+  const confidence = useConfidence();
+  const fontSize = useFlag('my-feature-flag.size', 12);
+
+  return (
+    <div>
+      <div style={{ fontSize }}>Client rendered content</div>
+      <button onClick={() => confidence.setContext({ locale: 'sv-SE' })}>Choose Swedish</button>
+    </div>
+  );
+};
+```
+
+#### In-depth
+
+Coming soon.
 
 ### Tracking events
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -20,7 +20,7 @@ The Confidence React integration has a Provider that needs to be initialized. It
 
 ```ts
 import { Confidence } from '@spotify-confidence/sdk/';
-import { ConfidenceProvider } from '@spotify-confidence/sdk/react/client';
+import { ConfidenceProvider } from '@spotify-confidence/sdk/react';
 
 // Client-side initialization
 const confidence = Confidence.create({
@@ -72,9 +72,9 @@ If the hooks can't resolve the flag values withing the timeout specified on the 
 
 ### Server-Side Rendering Support (experimental)
 
-The Confidence React SDK now supports server-side rendering (SSR) and React Server Components (RSC) for instance in Next.js. The SDK provides separate entry points for client and server components:
+The Confidence React SDK now supports server-side rendering (SSR) and React Server Components (RSC) for instance in Next.js. The SDK provides a separate entry point for server components:
 
-- `@spotify-confidence/react/client` - For client components
+- `@spotify-confidence/react` - For client components
 - `@spotify-confidence/react/server` - For server components
 
 When using the SDK in a server environment:

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -43,17 +43,11 @@ function App() {
 
 For server-side rendering setup, see the [Server-Side Rendering Support](#server-side-rendering-support) section below.
 
-Anywhere in the sub-tree under the `ConfidenceProvider` you can now access the confidence instance with the `useConfidence()` hook. The hook actually returns an instance of `ConfidenceReact` which is a wrapper around the normal `Confidence` API with some slight adaptations to integrate better with React. You can read more about the differences in the following sections.
+Anywhere in the sub-tree under the `ConfidenceProvider` you can now access the confidence instance with the `useConfidence()` hook to access context modification API's. For flag resolves we suggest using `useFlag()`.
 
 ### Managing context
 
-The `ConfidenceReact` instance supports the [standard context API](https://github.com/spotify/confidence-sdk-js/blob/main/packages/sdk/README.md#setting-the-context). Additionally, the following wrapper component can be used to wrap a sub tree with additional context data.
-
-```ts
-<ConfidenceProvider.WithContext context={{ user_name: 'John Doe' }}>
-  <UserDetails />
-</ConfidenceProvider.WithContext>
-```
+The `ConfidenceProvider` API supports a `useWithContext()` hook to achieve the [standard context API](https://github.com/spotify/confidence-sdk-js/blob/main/packages/sdk/README.md#setting-the-context).
 
 ### Accessing flags
 
@@ -62,11 +56,9 @@ Flags are accessed with a set of hooks exported from `@spotify-confidence/react`
 - `useFlag(flagName, defaultValue)` will return the flag value or default.
 - `useEvaluateFlag(flagName, defaultValue)` will return more details about the flag evaluation, together with the value.
 
-Alternatively the `ConfidenceReact` instance has the same hooks as methods on the instance itself, remember though, that these instance methods are hooks and the normal rules for hooks apply.
-
 Both of the flag hooks integrate with the React Suspense API so that the suspense fallback will be shown until flag values are available. It is therefore important to wrap any component using the above hooks in a suspense boundary.
 
-The hooks are also reactive so that if the context changes, any components using the hooks will be re-rendered. As dependent components are re-rendered as soon as the context changes, one might expect that would again trigger the suspense boundary while the flag values are resolved. That is normally not the case however as the `ConfidenceReact.setContext` method is by default wrapped in a React [Transition](https://react.dev/reference/react/startTransition). If you would rather manage the transition logic yourself (with for example [React.useTransition()](https://react.dev/reference/react/useTransition)), or if you want to always trigger a suspense fallback to never show stale values, you can turn off the default behavior by calling `ConfidenceReact.setContext({...}, { transition:false })`.
+The hooks are also reactive so that if the context changes, any components using the hooks will be re-rendered. As dependent components are re-rendered as soon as the context changes, one might expect that would again trigger the suspense boundary while the flag values are resolved.
 
 If the hooks can't resolve the flag values withing the timeout specified on the Confidence instance, they will instead return the default value.
 
@@ -80,7 +72,7 @@ The Confidence React SDK now supports server-side rendering (SSR) and React Serv
 When using the SDK in a server environment:
 
 1. Create a Confidence instance for server using the React.cache as the scope in CacheOptions.
-2. Provide an accessor for the Confidence instance using `withContext`.
+2. Optionally provide an accessor for the Confidence instance using `withContext` so you don't need to do that in every place.
 3. Use direct flag evaluation in server components.
 
 Here's an example of how to use Confidence in a Next.js application:
@@ -90,7 +82,7 @@ Here's an example of how to use Confidence in a Next.js application:
 import { Confidence } from '@spotify-confidence/sdk';
 import React from 'react';
 
-const confidence = Confidence.create({
+export const confidence = Confidence.create({
   clientSecret: process.env.CONFIDENCE_CLIENT_SECRET!,
   environment: 'backend',
   timeout: 1000,
@@ -100,22 +92,16 @@ const confidence = Confidence.create({
   },
 });
 
-// Confidence accessor for use in RSC.
-export const getConfidence = (context: Context): Confidence => {
-  return confidence.withContext(context);
-};
-
 // app/components/ServerComponent.tsx
 import { cookies } from 'next/headers';
-import { getConfidence } from '../confidence';
+import { confidence } from '../confidence';
 
 export const ServerComponent = async () => {
   const cookieStore = await cookies();
   const targeting_key = cookieStore.get('cnfdVisitorId')?.value; // or a unique targeting value of your choice
-  const confidence = getConfidence({ targeting_key });
 
   // Direct flag evaluation in server components
-  const color = await confidence.getFlag('my-feature-flag.color', 'blue');
+  const color = await confidence.withContext({ targeting_key }).getFlag('my-feature-flag.color', 'blue');
 
   return <div style={{ color }}>Server rendered content</div>;
 };

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -61,7 +61,7 @@ function MyComponent() {
   const color = useFlag('my-feature-flag.color', 'blue');
 
   // Detailed flag evaluation - returns evaluation details
-  const { value, reason, context } = useEvaluateFlag('my-feature-flag.size', 12);
+  const { value, reason } = useEvaluateFlag('my-feature-flag.size', 12);
 
   return (
     <div style={{ color, fontSize: value }}>

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -51,16 +51,82 @@ The `ConfidenceProvider` API supports a `useWithContext()` hook to achieve the [
 
 ### Accessing flags
 
-Flags are accessed with a set of hooks exported from `@spotify-confidence/react`
+Flags are accessed with a set of hooks exported from `@spotify-confidence/react`:
 
-- `useFlag(flagName, defaultValue)` will return the flag value or default.
-- `useEvaluateFlag(flagName, defaultValue)` will return more details about the flag evaluation, together with the value.
+```ts
+import { useFlag, useEvaluateFlag } from '@spotify-confidence/react';
 
-Both of the flag hooks integrate with the React Suspense API so that the suspense fallback will be shown until flag values are available. It is therefore important to wrap any component using the above hooks in a suspense boundary.
+function MyComponent() {
+  // Simple flag access - returns the flag value or default
+  const color = useFlag('my-feature-flag.color', 'blue');
 
-The hooks are also reactive so that if the context changes, any components using the hooks will be re-rendered. As dependent components are re-rendered as soon as the context changes, one might expect that would again trigger the suspense boundary while the flag values are resolved.
+  // Detailed flag evaluation - returns evaluation details
+  const { value, reason, context } = useEvaluateFlag('my-feature-flag.size', 12);
 
-If the hooks can't resolve the flag values withing the timeout specified on the Confidence instance, they will instead return the default value.
+  return (
+    <div style={{ color, fontSize: value }}>
+      <p>Color: {color}</p>
+      <p>Size: {value}</p>
+      <p>Reason: {reason}</p>
+    </div>
+  );
+}
+```
+
+#### Hook Behavior
+
+- `useFlag(flagName, defaultValue)`
+
+  - Returns the flag value or default
+  - Simplest way to access flag values
+  - Type-safe with TypeScript
+  - Example: `const isEnabled = useFlag('feature.enabled', false)`
+
+- `useEvaluateFlag(flagName, defaultValue)`
+  - Returns an object with:
+    - `value`: The flag value or default
+    - `reason`: The evaluation reason (e.g., "DEFAULT", "TARGETING_MATCH")
+    - `variant`: The variant assigned
+  - Useful for debugging or when you need evaluation details
+  - Example: `const { value, reason } = useEvaluateFlag('feature.color', 'blue')`
+
+#### Important Notes
+
+1. **Suspense Integration**
+
+   - Both hooks integrate with React Suspense
+   - Wrap components using these hooks in a Suspense boundary
+   - Example:
+
+   ```tsx
+   <Suspense fallback={<LoadingSpinner />}>
+     <MyComponent />
+   </Suspense>
+   ```
+
+2. **Reactivity**
+
+   - Hooks automatically re-render when context changes
+   - No need to manually trigger updates
+   - Example:
+
+   ```tsx
+   function MyComponent() {
+     const confidence = useConfidence();
+     const theme = useFlag('app.theme', 'light');
+
+     return <button onClick={() => confidence.setContext({ user_type: 'premium' })}>Switch to Premium</button>;
+   }
+   ```
+
+3. **Type Safety**
+   - Both hooks are fully typed with TypeScript
+   - The return type matches the default value type
+   - Example:
+   ```ts
+   const count: number = useFlag('counter.value', 0);
+   const name: string = useFlag('user.name', '');
+   ```
 
 ### Server-Side Rendering Support (experimental)
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -121,7 +121,10 @@ export const ServerComponent = async () => {
 };
 ```
 
-#### Server and Client
+> [!IMPORTANT]
+> Be aware that if you are constructing the Confidence instance using a custom `fetchImplementation` this will only be used on the server side.
+
+#### Server and Client (experimental)
 
 If you also have interactive (client side) components that benefit from feature flagging support.
 Using the pattern below in addition to the above server side example will allow you to have the flag evaluations
@@ -132,8 +135,12 @@ Please note:
 - Server components use direct flag evaluation with `evaluateFlag` or `getFlag`
 - Client components use hooks (`useFlag`, `useConfidence`) for interactive features
 - Use React.cache for efficient server-side caching
-- The SDK automatically handles synchronization between server and client
+- The SDK automatically handles synchronization from server to client
 - Mutating the context in a client side component does not affect the server side confidence instance.
+
+> [!IMPORTANT]
+> If your development environment uses TurboPack (e.g., Next.js with Turbopack enabled), please note that the
+> Confidence React SDK (server and client) is **not currently supported** with TurboPack. You'll need to use the standard webpack-based build system instead.
 
 ```tsx
 // app/layout.tsx

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,25 +3,31 @@
   "license": "Apache-2.0",
   "version": "0.1.1",
   "files": [
-    "dist/index.*"
+    "./index.*",
+    "./server.*"
   ],
   "scripts": {
     "bundle": "rollup -c && ../../validate-api.sh",
     "build": "tsc",
-    "prepack": "yarn build && yarn bundle",
-    "clean": "rm -rf {build,dist}"
+    "prepack": "yarn build && yarn bundle && cp dist/* .",
+    "clean": "rm -rf {build,dist}",
+    "postpack": "rm server.* & rm index.*"
   },
   "engineStrict": true,
   "engines": {
     "node": ">=18.17.0"
   },
+  "dependencies": {
+    "server-only": "^0.0.1"
+  },
   "peerDependencies": {
-    "@spotify-confidence/sdk": ">=0.1.4 <0.4.0",
-    "react": "^18.2.0"
+    "@spotify-confidence/sdk": ">=0.3.1 <0.4.0",
+    "react": "^18 || ^19"
   },
   "devDependencies": {
     "@spotify-confidence/sdk": "workspace:*",
-    "react": "^18.2.0",
+    "@types/react": "^18",
+    "react": "^19",
     "rollup": "4.24.0",
     "typescript": "5.1.6"
   },
@@ -29,21 +35,30 @@
     ".": {
       "import": "./build/index.js",
       "types": "./build/index.d.ts"
+    },
+    "./server": {
+      "import": "./build/server.js",
+      "types": "./build/server.d.ts"
     }
   },
   "type": "module",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",
+    "main": "index.cjs",
+    "module": "index.mjs",
+    "types": "index.d.ts",
     "exports": {
       ".": {
-        "import": "./dist/index.mjs",
-        "require": "./dist/index.cjs",
-        "types": "./dist/index.d.ts"
+        "import": "./index.mjs",
+        "require": "./index.cjs",
+        "types": "./index.d.ts"
+      },
+      "./server": {
+        "import": "./server.mjs",
+        "require": "./server.cjs",
+        "types": "./server.d.ts"
       }
-    },
-    "main": "dist/index.cjs",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts"
+    }
   }
 }

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -1,1 +1,6 @@
-export { default } from '../../rollup.base.mjs';
+import { createConfig } from '../../rollup.base.mjs';
+
+export default [
+  ...createConfig('build/index.js', { dts: true, banner: "'use client';" }),
+  ...createConfig('build/server.js', { dts: true }),
+];

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,204 +1,53 @@
-import {
-  Closer,
-  Confidence,
-  Value,
-  FlagEvaluation,
-  Context,
-  Configuration,
-  EventSender,
-  FlagResolver,
-  StateObserver,
-  Trackable,
-} from '@spotify-confidence/sdk';
-
+'use client';
+import { Confidence, Value, FlagEvaluation, Context, ConfidenceOptions } from '@spotify-confidence/sdk';
 import React, {
   createContext,
   FC,
   PropsWithChildren,
-  startTransition,
+  ReactNode,
   useContext,
   useEffect,
   useMemo,
   useState,
+  FunctionComponent,
 } from 'react';
 
-const ConfidenceContext = createContext<ConfidenceReact | null>(null);
+const isServer = typeof window === 'undefined';
+const ConfidenceContext = createContext<Confidence | null>(null);
 
-function isRendering(): boolean {
-  try {
-    // eslint-disable-next-line
-    useContext(ConfidenceContext);
-    return true;
-  } catch (e) {
-    return false;
-  }
-}
-
-/**
- * Confidence React instance
- * @public
- */
-export class ConfidenceReact implements EventSender, Trackable, FlagResolver {
-  /**
-   * Confidence Delegate
-   *  @internal */
-  readonly delegate: Confidence;
-
-  constructor(delegate: Confidence) {
-    this.delegate = delegate;
-  }
-  /** Return configurations of the Confidence instance */
-  get config(): Configuration {
-    return this.delegate.config;
-  }
-
-  /**
-   * Current serialized Context
-   * @internal */
-  get contextState(): string {
-    return Value.serialize(this.delegate.getContext());
-  }
-
-  /**
-   * Tracks an event
-   * @param name - event name
-   * @param message - data to track */
-  track(name: string, message?: Value.Struct): void;
-  /**
-   * Tracks an event
-   * @param manager - trackable manager */
-  track(manager: Trackable.Manager): Closer;
-  /**
-   * Tracks an event
-   * @param nameOrManager - event name or Trackable Manager */
-  track(nameOrManager: string | Trackable.Manager, message?: Value.Struct): Closer | undefined {
-    if (typeof nameOrManager === 'function') {
-      return this.delegate.track(nameOrManager);
-    }
-    this.delegate.track(nameOrManager, message);
-    return undefined;
-  }
-  /** Returns context of the current Confidence instance */
-  getContext(): Context {
-    this.assertContext('getContext', 'useContext');
-    return this.delegate.getContext();
-  }
-  /** Set Confidence context */
-  setContext(context: Context, { transition = true } = {}): void {
-    if (transition) {
-      startTransition(() => {
-        this.delegate.setContext(context);
-      });
-    } else {
-      this.delegate.setContext(context);
-    }
-  }
-
-  /** Subscribe to flag changes in Confidence */
-  subscribe(onStateChange?: StateObserver | undefined): () => void {
-    return this.delegate.subscribe(onStateChange);
-  }
-  /** Clears context of current Confidence instance */
-  clearContext({ transition = true } = {}): void {
-    if (transition) {
-      startTransition(() => {
-        this.delegate.clearContext();
-      });
-    } else {
-      this.delegate.clearContext();
-    }
-  }
-
-  /**
-   * Creates a new ConfidenceReact instance with context
-   * @param context - Confidence context
-   * @returns ConfidenceReact instance
-   */
-  withContext(context: Context): ConfidenceReact {
-    this.assertContext('withContext', 'useWithContext');
-    return new ConfidenceReact(this.delegate.withContext(context));
-  }
-  /** Evaluates a flag */
-  evaluateFlag(path: string, defaultValue: string): FlagEvaluation<string>;
-  evaluateFlag(path: string, defaultValue: boolean): FlagEvaluation<boolean>;
-  evaluateFlag(path: string, defaultValue: number): FlagEvaluation<number>;
-  evaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<T>;
-  evaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<T> {
-    this.assertContext('evaluateFlag', 'useEvaluateFlag');
-    return this.delegate.evaluateFlag(path, defaultValue);
-  }
-  /** Returns flag value for a given flag */
-  getFlag(path: string, defaultValue: string): Promise<string>;
-  getFlag(path: string, defaultValue: boolean): Promise<boolean>;
-  getFlag(path: string, defaultValue: number): Promise<number>;
-  getFlag<T extends Value>(path: string, defaultValue: T): Promise<T>;
-  getFlag<T extends Value>(path: string, defaultValue: T): Promise<T> {
-    this.assertContext('getFlag', 'useFlag');
-    return this.delegate.getFlag(path, defaultValue);
-  }
-
-  /* eslint-disable react-hooks/rules-of-hooks */
-
-  /** Hook to access Context */
-  useContext(): Context {
-    this.assertContext('useContext', 'getContext');
-    return useConfidenceContext(this);
-  }
-  /** Hook to access the WithContext functionality. Returns a  ConfidenceReact instance with the passed context. */
-  useWithContext(context: Context): ConfidenceReact {
-    this.assertContext('useWithContext', 'withContext');
-    return useWithContext(context, this);
-  }
-  /** Hook to use EvaluateFlag functionality */
-  useEvaluateFlag(path: string, defaultValue: string): FlagEvaluation<string>;
-  useEvaluateFlag(path: string, defaultValue: number): FlagEvaluation<number>;
-  useEvaluateFlag(path: string, defaultValue: boolean): FlagEvaluation<boolean>;
-  useEvaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<T>;
-  useEvaluateFlag<T extends Value>(path: string, defaultValue: T): FlagEvaluation<T> {
-    this.assertContext('useEvaluateFlag', 'evaluateFlag');
-    return useEvaluateFlag(path, defaultValue, this);
-  }
-  /** Hook to use getFlag functionality */
-  useFlag(path: string, defaultValue: string): string;
-  useFlag(path: string, defaultValue: number): number;
-  useFlag(path: string, defaultValue: boolean): boolean;
-  useFlag<T extends Value>(path: string, defaultValue: T): T;
-  useFlag<T extends Value>(path: string, defaultValue: T): T {
-    this.assertContext('useFlag', 'getFlag');
-    return useFlag(path, defaultValue, this);
-  }
-
-  /* eslint-enable react-hooks/rules-of-hooks */
-
-  private assertContext(fnName: string, altFnName: string) {
-    if (fnName.startsWith('use')) {
-      if (!isRendering())
-        throw new Error(
-          `${fnName} called outside the body of a function component. Did you mean to call ${altFnName}?`,
-        );
-    } else {
-      if (isRendering())
-        throw new Error(`${fnName} called inside the body of a function component. Did you mean to call ${altFnName}?`);
-    }
-  }
-}
-const _ConfidenceProvider: FC<PropsWithChildren<{ confidence: Confidence }>> = ({ confidence, children }) => {
-  const confidenceReact = useMemo(() => new ConfidenceReact(confidence), [confidence]);
-  return <ConfidenceContext.Provider value={confidenceReact} children={children} />;
+const _ConfidenceProvider = (props: { confidence: Confidence; children?: ReactNode }) => {
+  return <ConfidenceContext.Provider value={props.confidence} children={props.children} />;
 };
 
 const WithContext: FC<PropsWithChildren<{ context: Context }>> = ({ context, children }) => {
-  const child = useConfidence().useWithContext(context);
+  const child = useWithContext(context);
   return <ConfidenceContext.Provider value={child}>{children}</ConfidenceContext.Provider>;
 };
 
+declare function assertNever<T extends never>(): void;
+
+export const ManagedConfidenceProvider: FC<PropsWithChildren<{ options: ConfidenceOptions }>> = ({
+  options,
+  children,
+}) => {
+  const confidence = useMemo(
+    () =>
+      Confidence.create({
+        ...options,
+        environment: 'client',
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    Object.values(options),
+  );
+  return _ConfidenceProvider({ confidence, children });
+};
 /**
  * Confidence Provider for React
  * @public
  */
-export type ConfidenceProvider = FC<PropsWithChildren<{ confidence: Confidence }>> & {
+export interface ConfidenceProvider extends FunctionComponent<{ confidence: Confidence; children?: ReactNode }> {
   WithContext: FC<PropsWithChildren<{ context: Context }>>;
-};
+}
 /**
  * Confidence Provider for React
  * @public
@@ -210,11 +59,11 @@ export const ConfidenceProvider: ConfidenceProvider = Object.assign(_ConfidenceP
  * Enables using Confidence
  * @public
  */
-export const useConfidence = (): ConfidenceReact => {
-  const confidenceReact = useContext(ConfidenceContext);
-  if (!confidenceReact)
+export const useConfidence = (): Confidence => {
+  const confidence = useContext(ConfidenceContext);
+  if (!confidence)
     throw new Error('No Confidence instance found, did you forget to wrap your component in ConfidenceProvider?');
-  return confidenceReact;
+  return confidence;
 };
 
 /**
@@ -222,9 +71,9 @@ export const useConfidence = (): ConfidenceReact => {
  * @public
  */
 // eslint-disable-next-line react-hooks/rules-of-hooks
-export function useWithContext(context: Context, parent = useConfidence()): ConfidenceReact {
+export function useWithContext(context: Context, parent = useConfidence()): Confidence {
   const child = useMemo(
-    () => new ConfidenceReact(parent.delegate.withContext(context)),
+    () => parent.withContext(context),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [parent, Value.serialize(context)],
   );
@@ -239,35 +88,22 @@ export function useWithContext(context: Context, parent = useConfidence()): Conf
 // this would be better named useContext, but would then collide with React.useContext
 // eslint-disable-next-line react-hooks/rules-of-hooks
 export function useConfidenceContext(confidence = useConfidence()): Context {
-  const [, setState] = useState(confidence.contextState);
-  useEffect(() => {
-    return confidence.delegate.contextChanges(() => setState(confidence.contextState));
-  });
-  return confidence.delegate.getContext();
+  const [, setState] = useState(Value.serialize(confidence.getContext()));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(confidence.contextChanges(() => setState(Value.serialize(confidence.getContext()))));
+  return confidence.getContext();
 }
 
 /**
  * Use EvaluateFlag
  * @public */
-export function useEvaluateFlag(
-  path: string,
-  defaultValue: string,
-  confidence?: ConfidenceReact,
-): FlagEvaluation<string>;
-export function useEvaluateFlag(
-  path: string,
-  defaultValue: number,
-  confidence?: ConfidenceReact,
-): FlagEvaluation<number>;
-export function useEvaluateFlag(
-  path: string,
-  defaultValue: boolean,
-  confidence?: ConfidenceReact,
-): FlagEvaluation<boolean>;
+export function useEvaluateFlag(path: string, defaultValue: string, confidence?: Confidence): FlagEvaluation<string>;
+export function useEvaluateFlag(path: string, defaultValue: number, confidence?: Confidence): FlagEvaluation<number>;
+export function useEvaluateFlag(path: string, defaultValue: boolean, confidence?: Confidence): FlagEvaluation<boolean>;
 export function useEvaluateFlag<T extends Value>(
   path: string,
   defaultValue: T,
-  confidence?: ConfidenceReact,
+  confidence?: Confidence,
 ): FlagEvaluation<T>;
 export function useEvaluateFlag<T extends Value>(
   path: string,
@@ -275,14 +111,19 @@ export function useEvaluateFlag<T extends Value>(
   // eslint-disable-next-line react-hooks/rules-of-hooks
   confidence = useConfidence(),
 ): FlagEvaluation<T> {
-  const evaluation = confidence.delegate.evaluateFlag(path, defaultValue);
-  const [, setState] = useState(() => confidence.contextState);
+  const evaluation = confidence.evaluateFlag(path, defaultValue);
+  const [, setState] = useState(() => Value.serialize(confidence.getContext()));
   useEffect(() => {
     return confidence.subscribe(() => {
-      setState(confidence.contextState);
+      setState(Value.serialize(confidence.getContext()));
     });
   });
-  if ('then' in evaluation) throw evaluation;
+  if ('then' in evaluation) {
+    if (isServer) {
+      throw Object.assign(new Error('Flags are not fetched in SSR'), { digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING' });
+    }
+    throw evaluation;
+  }
   return evaluation;
 }
 
@@ -290,10 +131,10 @@ export function useEvaluateFlag<T extends Value>(
  * Use Flag
  * @public
  */
-export function useFlag(path: string, defaultValue: string, confidence?: ConfidenceReact): string;
-export function useFlag(path: string, defaultValue: number, confidence?: ConfidenceReact): number;
-export function useFlag(path: string, defaultValue: boolean, confidence?: ConfidenceReact): boolean;
-export function useFlag<T extends Value>(path: string, defaultValue: T, confidence?: ConfidenceReact): T;
+export function useFlag(path: string, defaultValue: string, confidence?: Confidence): string;
+export function useFlag(path: string, defaultValue: number, confidence?: Confidence): number;
+export function useFlag(path: string, defaultValue: boolean, confidence?: Confidence): boolean;
+export function useFlag<T extends Value>(path: string, defaultValue: T, confidence?: Confidence): T;
 // eslint-disable-next-line react-hooks/rules-of-hooks
 export function useFlag<T extends Value>(path: string, defaultValue: T, confidence = useConfidence()): T {
   return useEvaluateFlag(path, defaultValue, confidence).value;

--- a/packages/react/src/server.tsx
+++ b/packages/react/src/server.tsx
@@ -1,0 +1,31 @@
+import { Confidence } from '@spotify-confidence/sdk';
+import React, { ReactNode } from 'react';
+import { ManagedConfidenceProvider } from '@spotify-confidence/react';
+import 'server-only';
+
+export async function ConfidenceProvider(props: { confidence: Confidence; children?: ReactNode }) {
+  let close: (() => void) | undefined;
+  const options = props.confidence.toOptions();
+  if (options.cache && options.cache.entries) {
+    const entries = options.cache.entries;
+    const keepOpen = new Promise<void>(resolve => {
+      close = resolve;
+    });
+    options.cache.entries = {
+      async *[Symbol.asyncIterator]() {
+        await keepOpen;
+        yield* entries;
+      },
+    };
+  }
+  const Trailer = () => {
+    close?.();
+    return null;
+  };
+  return (
+    <ManagedConfidenceProvider options={options}>
+      {props.children}
+      <Trailer />
+    </ManagedConfidenceProvider>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3765,12 +3765,14 @@ __metadata:
   resolution: "@spotify-confidence/react@workspace:packages/react"
   dependencies:
     "@spotify-confidence/sdk": "workspace:*"
-    react: "npm:^18.2.0"
+    "@types/react": "npm:^18"
+    react: "npm:^19"
     rollup: "npm:4.24.0"
+    server-only: "npm:^0.0.1"
     typescript: "npm:5.1.6"
   peerDependencies:
-    "@spotify-confidence/sdk": ">=0.1.4 <0.4.0"
-    react: ^18.2.0
+    "@spotify-confidence/sdk": ">=0.3.1 <0.4.0"
+    react: ^18 || ^19
   languageName: unknown
   linkType: soft
 
@@ -4634,7 +4636,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*, @types/react@npm:^18.2.17":
+"@types/react@npm:*":
   version: 18.2.17
   resolution: "@types/react@npm:18.2.17"
   dependencies:
@@ -4642,6 +4644,16 @@ __metadata:
     "@types/scheduler": "npm:*"
     csstype: "npm:^3.0.2"
   checksum: 10c0/3a90c1614765a03fc83408cfe7fd75a5284fad96014241654f59e64bf004bed81df3e757eff73310c8d332523e1d2b32230e35d9496f608a1ced93f9ca06a26e
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:^18":
+  version: 18.3.20
+  resolution: "@types/react@npm:18.3.20"
+  dependencies:
+    "@types/prop-types": "npm:*"
+    csstype: "npm:^3.0.2"
+  checksum: 10c0/65fa867c91357e4c4c646945c8b99044360f8973cb7f928ec4de115fe3207827985d45be236e6fd6c092b09f631c2126ce835c137be30718419e143d73300d8f
   languageName: node
   linkType: hard
 
@@ -15004,6 +15016,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react@npm:^19":
+  version: 19.1.0
+  resolution: "react@npm:19.1.0"
+  checksum: 10c0/530fb9a62237d54137a13d2cfb67a7db6a2156faed43eecc423f4713d9b20c6f2728b026b45e28fcd72e8eadb9e9ed4b089e99f5e295d2f0ad3134251bdd3698
+  languageName: node
+  linkType: hard
+
 "read-cache@npm:^1.0.0":
   version: 1.0.0
   resolution: "read-cache@npm:1.0.0"
@@ -15598,7 +15617,6 @@ __metadata:
     "@spotify/tsconfig": "npm:^15.0.0"
     "@swc/core": "npm:^1.4.13"
     "@types/jest": "npm:^29.5.3"
-    "@types/react": "npm:^18.2.17"
     "@typescript-eslint/eslint-plugin": "npm:^5.62.0"
     "@typescript-eslint/parser": "npm:^5.62.0"
     "@yarnpkg/types": "npm:^4.0.0"
@@ -15943,6 +15961,13 @@ __metadata:
     parseurl: "npm:~1.3.3"
     send: "npm:0.19.0"
   checksum: 10c0/528fff6f5e12d0c5a391229ad893910709bc51b5705962b09404a1d813857578149b8815f35d3ee5752f44cd378d0f31669d4b1d7e2d11f41e08283d5134bd1f
+  languageName: node
+  linkType: hard
+
+"server-only@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "server-only@npm:0.0.1"
+  checksum: 10c0/4704f0ef85da0be981af6d4ed8e739d39bcfd265b9c246a684060acda5642d0fdc6daffc2308e71e2682c5f508090978802eae0a77623c9b90a49f9ae68048d6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
BREAKING CHANGE:
Previously, when you did `useConfidence`, the returned instance would be augmented with extra hook-like functions such as `useFlag`. These have been removed and you should just use the exported top level hooks.

---------

