### PR TITLE
fix: include logger in toOptions

### DIFF
--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -345,6 +345,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
       environment: this.config.environment,
       cache,
       context: this.getContext(),
+      logger: this.config.logger,
     };
   }
 


### PR DESCRIPTION
Including logger in toOptions ensures that we respect logging settings on the client as well.