### PR TITLE
fix: update the resolver tester message to exclude link

### DIFF
--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -15,6 +15,7 @@ import { AccessiblePromise } from './AccessiblePromise';
 import { Telemetry } from './Telemetry';
 import { SimpleFetch } from './fetch-util';
 import { CacheOptions, CacheProvider, FlagCache } from './flag-cache';
+import { utf8ToBase64 } from './utils';
 
 /**
  * Confidence options, to be used for easier initialization of Confidence
@@ -329,11 +330,15 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
   }
 
   private showLoggerLink(flag: string, context: Context) {
-    this.config.logger.info?.(
-      `See resolves for '${flag}' in Confidence: https://app.confidence.spotify.com/flags/resolver-test?client-key=${
-        this.config.clientSecret
-      }&flag=flags/${flag}&context=${encodeURIComponent(JSON.stringify(context))}`,
-    );
+    const data = {
+      clientKey: this.config.clientSecret,
+      flag,
+      context,
+    };
+    const jsonString = JSON.stringify(data);
+    const base64 =
+      typeof window !== 'undefined' ? utf8ToBase64(jsonString) : Buffer.from(jsonString).toString('base64');
+    this.config.logger.info?.(`Use Confidence Flags resolve tester for more information about '${flag}': ${base64}`);
   }
 
   toOptions(): ConfidenceOptions {

--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -338,7 +338,9 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     const jsonString = JSON.stringify(data);
     const base64 =
       typeof window !== 'undefined' ? utf8ToBase64(jsonString) : Buffer.from(jsonString).toString('base64');
-    this.config.logger.info?.(`Use Confidence Flags resolve tester for more information about '${flag}': ${base64}`);
+    this.config.logger.info?.(
+      `Check your flag evaluation for '${flag}' by copy-pasting the payload to the Resolve tester: ${base64}`,
+    );
   }
 
   toOptions(): ConfidenceOptions {

--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -332,7 +332,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
   private showLoggerLink(flag: string, context: Context) {
     const data = {
       clientKey: this.config.clientSecret,
-      flag,
+      flag: `flags/${flag}`,
       context,
     };
     const jsonString = JSON.stringify(data);

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -40,10 +40,7 @@ export function uuid(): string {
 export function utf8ToBase64(str: string): string {
   const encoder = new TextEncoder();
   const bytes = encoder.encode(str);
-  let binary = '';
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
+  const binary = String.fromCharCode(...bytes);
   return btoa(binary);
 }
 

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -37,6 +37,16 @@ export function uuid(): string {
   return 'xxxxxxxx-xxxx-4xxx-xxxx-xxxxxxxxxxxx'.replace(/x/g, () => HEX_ALPHA[(Math.random() * 16) | 0]);
 }
 
+export function utf8ToBase64(str: string): string {
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(str);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
 export namespace Cookie {
   type Options = {
     sameSite?: boolean;


### PR DESCRIPTION
Resolver hint logs will now contain a base64 encoded string which can be pasted in the Confidence tools to support that we don't necessarily know the URL the user would want to use.