### PR TITLE
feat: allow passing a client side logger for react-server

### DIFF
--- a/api/react-server.d.ts
+++ b/api/react-server.d.ts
@@ -1,8 +1,9 @@
-import { Confidence } from '@spotify-confidence/sdk';
+import { Confidence, Logger } from '@spotify-confidence/sdk';
 import React, { ReactNode } from 'react';
 
 declare function ConfidenceProvider(props: {
     confidence: Confidence;
+    clientLogger?: Logger;
     children?: ReactNode;
 }): Promise<React.JSX.Element>;
 

--- a/api/sdk.api.md
+++ b/api/sdk.api.md
@@ -80,7 +80,6 @@ export interface ConfidenceOptions {
     disableTelemetry?: boolean;
     environment: 'client' | 'backend';
     fetchImplementation?: SimpleFetch;
-    // Warning: (ae-forgotten-export) The symbol "Logger" needs to be exported by the entry point index.d.ts
     logger?: Logger;
     region?: 'eu' | 'us';
     resolveBaseUrl?: string;
@@ -172,6 +171,37 @@ export interface FlagResolver extends Contextual<FlagResolver> {
     getFlag(path: string, defaultValue: number): Promise<number>;
     getFlag<T extends Value>(path: string, defaultValue: T): Promise<T>;
     subscribe(onStateChange?: StateObserver): () => void;
+}
+
+// Warning: (ae-missing-release-tag) "Logger" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Logger" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export namespace Logger {
+    const // (undocumented)
+    LEVELS: readonly ["trace", "debug", "info", "warn", "error"];
+    // (undocumented)
+    export type Fn = (message: string, ...optionalParams: any[]) => void;
+    // (undocumented)
+    export type Level = (typeof LEVELS)[number];
+    // (undocumented)
+    export function noOp(): Logger;
+    // (undocumented)
+    export function withLevel(delegate: Logger, level: Level): Logger;
+}
+
+// @public (undocumented)
+export interface Logger {
+    // (undocumented)
+    readonly debug?: Logger.Fn;
+    // (undocumented)
+    readonly error?: Logger.Fn;
+    // (undocumented)
+    readonly info?: Logger.Fn;
+    // (undocumented)
+    readonly trace?: Logger.Fn;
+    // (undocumented)
+    readonly warn?: Logger.Fn;
 }
 
 // @public

--- a/packages/react/src/server.tsx
+++ b/packages/react/src/server.tsx
@@ -1,9 +1,13 @@
-import { Confidence } from '@spotify-confidence/sdk';
+import { Confidence, Logger } from '@spotify-confidence/sdk';
 import React, { ReactNode } from 'react';
 import { ManagedConfidenceProvider } from '@spotify-confidence/react';
 import 'server-only';
 
-export async function ConfidenceProvider(props: { confidence: Confidence; children?: ReactNode }) {
+export async function ConfidenceProvider(props: {
+  confidence: Confidence;
+  clientLogger?: Logger;
+  children?: ReactNode;
+}) {
   let close: (() => void) | undefined;
   const options = props.confidence.toOptions();
   if (options.cache && options.cache.entries) {
@@ -17,6 +21,9 @@ export async function ConfidenceProvider(props: { confidence: Confidence; childr
         yield* entries;
       },
     };
+  }
+  if (props.clientLogger) {
+    options.logger = props.clientLogger;
   }
   const Trailer = () => {
     if (close) {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -7,5 +7,6 @@ export * from './trackers';
 export * from './Trackable';
 export * from './Closer';
 export * from './types';
+export * from './logger';
 export { SimpleFetch } from './fetch-util';
 export { CacheOptions, CacheScope } from './flag-cache';


### PR DESCRIPTION
When running a Next app and using the console logger when creating the confidence instance. The client side instance "lost" the logger. Since we cannot pass the logger between server and client we can allow to set a specific client side logger.