### PR TITLE
feat: Pass null in the wire

### DIFF
--- a/api/sdk.api.md
+++ b/api/sdk.api.md
@@ -230,7 +230,7 @@ export namespace Value {
 }
 
 // @public
-export type Value = Value.Primitive | Value.Struct | Value.List | undefined;
+export type Value = Value.Primitive | Value.Struct | Value.List | undefined | null;
 
 // @public
 export const visitorIdentity: () => Trackable.Manager;

--- a/packages/openfeature-server-provider/src/ConfidenceServerProvider.ts
+++ b/packages/openfeature-server-provider/src/ConfidenceServerProvider.ts
@@ -102,7 +102,7 @@ function convertContext({ targetingKey, ...context }: EvaluationContext): Contex
 
 function convertValue(value: EvaluationContextValue): Value {
   if (typeof value === 'object') {
-    if (value === null) return undefined;
+    if (value === null) return null;
     if (value instanceof Date) return value.toISOString();
     // @ts-expect-error TODO fix single type array conversion
     if (Array.isArray(value)) return value.map(convertValue);

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
@@ -153,7 +153,7 @@ function convertContext({ targetingKey, ...context }: EvaluationContext): Contex
 
 function convertValue(value: EvaluationContextValue): Value {
   if (typeof value === 'object') {
-    if (value === null) return undefined;
+    if (value === null) return null as unknown as Value;
     if (value instanceof Date) return value.toISOString();
     // @ts-expect-error TODO fix single type array conversion
     if (Array.isArray(value)) return value.map(convertValue);

--- a/packages/sdk/src/Confidence.e2e.test.ts
+++ b/packages/sdk/src/Confidence.e2e.test.ts
@@ -24,6 +24,17 @@ describe('Confidence E2E Tests', () => {
         variant: 'flags/web-sdk-e2e-flag/variants/control',
       });
     });
+
+    it('should evaluate a flag with null pants context', async () => {
+      const evaluation = await confidence
+        .withContext({ visitor_id: 'test-a', pants: null })
+        .evaluateFlag('web-sdk-e2e-flag.int', 0);
+      expect(evaluation).toEqual({
+        reason: 'MATCH',
+        value: null,
+        variant: 'flags/web-sdk-e2e-flag/variants/treatment-2',
+      });
+    });
   });
 
   describe('track event sends an event', () => {

--- a/packages/sdk/src/Confidence.test.ts
+++ b/packages/sdk/src/Confidence.test.ts
@@ -75,7 +75,6 @@ describe('Confidence', () => {
 
     it('treats null values as undefined in context', () => {
       confidence.setContext({ pants: 'yellow' });
-      // @ts-expect-error null is not a valid Value type
       confidence.setContext({ pants: null });
       expect(confidence.getContext()).toEqual({});
     });

--- a/packages/sdk/src/Value.ts
+++ b/packages/sdk/src/Value.ts
@@ -345,4 +345,4 @@ export namespace Value {
 }
 /** Confidence used Values */
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export type Value = Value.Primitive | Value.Struct | Value.List | undefined;
+export type Value = Value.Primitive | Value.Struct | Value.List | undefined | null;


### PR DESCRIPTION
With this we get

```
    resolveFlagsJson {
      evaluationContext: { visitor_id: 'test-a', pants: null },
      clientSecret: 'RxDVTrXvc6op1XxiQ4OaR31dKbJ39aYV',
      sdk: { id: 'SDK_ID_JS_CONFIDENCE', version: '0.3.2' }
    }
```