### PR TITLE
fix: add support for resolveUrl in createConfidenceServerProvider()

### DIFF
--- a/api/openfeature-server-provider.d.ts
+++ b/api/openfeature-server-provider.d.ts
@@ -32,6 +32,8 @@ type ConfidenceProviderFactoryOptions = {
     fetchImplementation?: typeof fetch;
     clientSecret: string;
     timeout: number;
+    /** Sets an alternative resolve url */
+    resolveBaseUrl?: string;
 };
 /**
  * Creates an OpenFeature-adhering Confidence Provider

--- a/packages/openfeature-server-provider/src/factory.ts
+++ b/packages/openfeature-server-provider/src/factory.ts
@@ -10,6 +10,8 @@ export type ConfidenceProviderFactoryOptions = {
   fetchImplementation?: typeof fetch;
   clientSecret: string;
   timeout: number;
+  /** Sets an alternative resolve url */
+  resolveBaseUrl?: string;
 };
 
 /**


### PR DESCRIPTION
This will allow you to pass the `resolveBaseUrl` directly when using `createConfidenceServerProvider()`
