### PR TITLE
fix: defensively reject if aborted during response.json()

### DIFF
--- a/packages/sdk/src/FlagResolverClient.ts
+++ b/packages/sdk/src/FlagResolverClient.ts
@@ -25,10 +25,7 @@ const FLAG_PREFIX = 'flags/';
 const retryCodes = new Set([408, 502, 503, 504]);
 
 export class ResolveError extends Error {
-  constructor(
-    public readonly code: FlagEvaluation.ErrorCode,
-    message: string,
-  ) {
+  constructor(public readonly code: FlagEvaluation.ErrorCode, message: string) {
     super(message);
   }
 }


### PR DESCRIPTION
When running Confidence on constrained resources we could see that a evaluateFlag call could hang indefinitely if the timeout triggered (abortsignal fired) between the time that the response headers came back and the time Node was finished consuming the fetch stream and transforming it to json.

We now manually make sure that the timeout signal is respected.
