### PR TITLE
fix(sdk): migrate host-scoped visitor cookie when domain is set

### DIFF
--- a/packages/sdk/src/trackers/visitorId.test.ts
+++ b/packages/sdk/src/trackers/visitorId.test.ts
@@ -15,12 +15,17 @@ function mockController(): Trackable.Controller {
   };
 }
 
-function mockCookieStore(cookies: Array<{ name: string; value: string; domain: string }>) {
+function mockCookieStore(cookies: Array<{ name: string; value: string; domain: string | null }>) {
   const store = {
     getAll: jest.fn(async (name: string) => cookies.filter(c => c.name === name)),
-    delete: jest.fn(async ({ name, domain }: { name: string; domain: string }) => {
-      const idx = cookies.findIndex(c => c.name === name && c.domain === domain);
-      if (idx >= 0) cookies.splice(idx, 1);
+    delete: jest.fn(async (nameOrOptions: string | { name: string; domain: string }) => {
+      if (typeof nameOrOptions === 'string') {
+        const idx = cookies.findIndex(c => c.name === nameOrOptions && c.domain === null);
+        if (idx >= 0) cookies.splice(idx, 1);
+      } else {
+        const idx = cookies.findIndex(c => c.name === nameOrOptions.name && c.domain === nameOrOptions.domain);
+        if (idx >= 0) cookies.splice(idx, 1);
+      }
     }),
   };
   (globalThis as any).cookieStore = store;
@@ -92,7 +97,7 @@ describe('visitorIdentity', () => {
     });
 
     it('migrates host cookie to domain cookie', async () => {
-      const cookies = [{ name: 'cnfdVisitorId', value: 'host-value', domain: 'app.example.com' }];
+      const cookies = [{ name: 'cnfdVisitorId', value: 'host-value', domain: null as string | null }];
       const store = mockCookieStore(cookies);
       Cookie.set('cnfdVisitorId', 'host-value', { maxAge: 1000 });
 
@@ -102,7 +107,7 @@ describe('visitorIdentity', () => {
       visitorIdentity({ domain: 'example.com' })(controller);
       await flushPromises();
 
-      expect(store.delete).toHaveBeenCalledWith({ name: 'cnfdVisitorId', domain: 'app.example.com' });
+      expect(store.delete).toHaveBeenCalledWith('cnfdVisitorId');
       expect(setSpy).toHaveBeenCalledWith(
         'cnfdVisitorId',
         'host-value',
@@ -113,7 +118,7 @@ describe('visitorIdentity', () => {
 
     it('preserves existing domain cookie and deletes host cookie', async () => {
       const cookies = [
-        { name: 'cnfdVisitorId', value: 'host-value', domain: 'app.example.com' },
+        { name: 'cnfdVisitorId', value: 'host-value', domain: null as string | null },
         { name: 'cnfdVisitorId', value: 'domain-value', domain: 'example.com' },
       ];
       const store = mockCookieStore(cookies);
@@ -130,7 +135,7 @@ describe('visitorIdentity', () => {
       await flushPromises();
 
       // Async: host cookie deleted, domain cookie preserved, context updated
-      expect(store.delete).toHaveBeenCalledWith({ name: 'cnfdVisitorId', domain: 'app.example.com' });
+      expect(store.delete).toHaveBeenCalledWith('cnfdVisitorId');
       expect(store.delete).not.toHaveBeenCalledWith(expect.objectContaining({ domain: 'example.com' }));
       expect(controller.setContext).toHaveBeenCalledWith({ visitor_id: 'domain-value' });
       setSpy.mockRestore();

--- a/packages/sdk/src/trackers/visitorId.test.ts
+++ b/packages/sdk/src/trackers/visitorId.test.ts
@@ -1,0 +1,193 @@
+/**
+ * @jest-environment jsdom
+ */
+import { visitorIdentity } from './visitorId';
+import { Cookie } from '../utils';
+import { Trackable } from '../Trackable';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+function mockController(): Trackable.Controller {
+  return {
+    setContext: jest.fn().mockReturnValue(true),
+    track: jest.fn() as any,
+    config: {} as any,
+  };
+}
+
+function mockCookieStore(cookies: Array<{ name: string; value: string; domain: string }>) {
+  const store = {
+    getAll: jest.fn(async (name: string) => cookies.filter(c => c.name === name)),
+    delete: jest.fn(async ({ name, domain }: { name: string; domain: string }) => {
+      const idx = cookies.findIndex(c => c.name === name && c.domain === domain);
+      if (idx >= 0) cookies.splice(idx, 1);
+    }),
+  };
+  (globalThis as any).cookieStore = store;
+  return store;
+}
+
+beforeEach(() => {
+  document.cookie.split(';').forEach(c => {
+    const name = c.split('=')[0].trim();
+    if (name) document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+  });
+  delete (globalThis as any).cookieStore;
+});
+
+describe('visitorIdentity', () => {
+  describe('without domain', () => {
+    it('generates a new visitor id when no cookie exists', () => {
+      const controller = mockController();
+      visitorIdentity()(controller);
+
+      expect(controller.setContext).toHaveBeenCalledWith({
+        visitor_id: expect.stringMatching(UUID_PATTERN),
+      });
+      expect(Cookie.get('cnfdVisitorId')).toBeDefined();
+    });
+
+    it('reuses existing cookie value', () => {
+      Cookie.set('cnfdVisitorId', 'existing-id', { maxAge: 1000 });
+      const controller = mockController();
+      visitorIdentity()(controller);
+
+      expect(controller.setContext).toHaveBeenCalledWith({ visitor_id: 'existing-id' });
+    });
+  });
+
+  describe('with domain, no CookieStore', () => {
+    it('sets a domain-scoped cookie', () => {
+      const controller = mockController();
+      const setSpy = jest.spyOn(Cookie, 'set');
+      visitorIdentity({ domain: '.example.com' })(controller);
+
+      expect(controller.setContext).toHaveBeenCalledWith({
+        visitor_id: expect.stringMatching(UUID_PATTERN),
+      });
+      expect(setSpy).toHaveBeenCalledWith('cnfdVisitorId', expect.any(String), {
+        maxAge: expect.any(Number),
+        domain: '.example.com',
+      });
+      setSpy.mockRestore();
+    });
+  });
+
+  describe('with domain and CookieStore', () => {
+    it('sets domain cookie when no cookies exist', async () => {
+      const store = mockCookieStore([]);
+      const setSpy = jest.spyOn(Cookie, 'set');
+      const controller = mockController();
+
+      visitorIdentity({ domain: 'example.com' })(controller);
+      await flushPromises();
+
+      expect(store.getAll).toHaveBeenCalledWith('cnfdVisitorId');
+      expect(setSpy).toHaveBeenCalledWith(
+        'cnfdVisitorId',
+        expect.stringMatching(UUID_PATTERN),
+        expect.objectContaining({ domain: 'example.com' }),
+      );
+      setSpy.mockRestore();
+    });
+
+    it('migrates host cookie to domain cookie', async () => {
+      const cookies = [{ name: 'cnfdVisitorId', value: 'host-value', domain: 'app.example.com' }];
+      const store = mockCookieStore(cookies);
+      Cookie.set('cnfdVisitorId', 'host-value', { maxAge: 1000 });
+
+      const setSpy = jest.spyOn(Cookie, 'set');
+      const controller = mockController();
+
+      visitorIdentity({ domain: 'example.com' })(controller);
+      await flushPromises();
+
+      expect(store.delete).toHaveBeenCalledWith({ name: 'cnfdVisitorId', domain: 'app.example.com' });
+      expect(setSpy).toHaveBeenCalledWith(
+        'cnfdVisitorId',
+        'host-value',
+        expect.objectContaining({ domain: 'example.com' }),
+      );
+      setSpy.mockRestore();
+    });
+
+    it('preserves existing domain cookie and deletes host cookie', async () => {
+      const cookies = [
+        { name: 'cnfdVisitorId', value: 'host-value', domain: 'app.example.com' },
+        { name: 'cnfdVisitorId', value: 'domain-value', domain: 'example.com' },
+      ];
+      const store = mockCookieStore(cookies);
+      Cookie.set('cnfdVisitorId', 'host-value', { maxAge: 1000 });
+
+      const setSpy = jest.spyOn(Cookie, 'set');
+      const controller = mockController();
+
+      visitorIdentity({ domain: 'example.com' })(controller);
+
+      // Sync: context set with host value (most specific)
+      expect(controller.setContext).toHaveBeenCalledWith({ visitor_id: 'host-value' });
+
+      await flushPromises();
+
+      // Async: host cookie deleted, domain cookie preserved, context updated
+      expect(store.delete).toHaveBeenCalledWith({ name: 'cnfdVisitorId', domain: 'app.example.com' });
+      expect(store.delete).not.toHaveBeenCalledWith(expect.objectContaining({ domain: 'example.com' }));
+      expect(controller.setContext).toHaveBeenCalledWith({ visitor_id: 'domain-value' });
+      setSpy.mockRestore();
+    });
+
+    it('normalizes domain with leading dot', async () => {
+      Cookie.set('cnfdVisitorId', 'domain-value', { maxAge: 1000 });
+      const cookies = [{ name: 'cnfdVisitorId', value: 'domain-value', domain: '.example.com' }];
+      mockCookieStore(cookies);
+
+      const controller = mockController();
+      visitorIdentity({ domain: 'example.com' })(controller);
+      await flushPromises();
+
+      // Domain cookie matched despite leading dot — no duplicate setContext
+      expect(controller.setContext).toHaveBeenCalledTimes(1);
+      expect(controller.setContext).toHaveBeenCalledWith({ visitor_id: 'domain-value' });
+    });
+
+    it('falls back to simple set when CookieStore throws', async () => {
+      (globalThis as any).cookieStore = {
+        getAll: jest.fn().mockRejectedValue(new Error('not allowed')),
+        delete: jest.fn(),
+      };
+      const setSpy = jest.spyOn(Cookie, 'set');
+      const controller = mockController();
+
+      visitorIdentity({ domain: 'example.com' })(controller);
+      await flushPromises();
+
+      expect(setSpy).toHaveBeenCalledWith(
+        'cnfdVisitorId',
+        expect.any(String),
+        expect.objectContaining({ domain: 'example.com' }),
+      );
+      setSpy.mockRestore();
+    });
+  });
+
+  describe('SSR', () => {
+    it('does nothing when document is undefined', () => {
+      const originalDocument = globalThis.document;
+      // @ts-expect-error - testing SSR
+      delete globalThis.document;
+      try {
+        const controller = mockController();
+        visitorIdentity()(controller);
+        expect(controller.setContext).not.toHaveBeenCalled();
+      } finally {
+        globalThis.document = originalDocument;
+      }
+    });
+  });
+});
+
+function flushPromises(): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, 0);
+  });
+}

--- a/packages/sdk/src/trackers/visitorId.ts
+++ b/packages/sdk/src/trackers/visitorId.ts
@@ -2,6 +2,7 @@ import { Trackable } from '../Trackable';
 import { uuid, Cookie } from '../utils';
 
 const COOKIE_NAME = 'cnfdVisitorId';
+const MAX_AGE = 60 * 60 * 24 * 365 * 5;
 
 /**
  * Options for the visitor identity tracker.
@@ -12,6 +13,51 @@ export type VisitorIdentityOptions = {
   domain?: string;
 };
 
+interface CookieStoreEntry {
+  name: string;
+  value: string;
+  domain: string;
+}
+
+interface CookieStore {
+  getAll(name: string): Promise<CookieStoreEntry[]>;
+  delete(options: { name: string; domain: string }): Promise<void>;
+}
+
+declare const cookieStore: CookieStore | undefined;
+
+function normalizeDomain(d: string): string {
+  return d.startsWith('.') ? d.slice(1) : d;
+}
+
+async function migrateWithCookieStore(
+  name: string,
+  currentValue: string,
+  domain: string,
+  controller: Trackable.Controller,
+): Promise<void> {
+  try {
+    const cookies = await cookieStore!.getAll(name);
+    const normalizedDomain = normalizeDomain(domain);
+    const domainCookie = cookies.find(c => normalizeDomain(c.domain) === normalizedDomain);
+    const hostCookies = cookies.filter(c => c !== domainCookie);
+
+    for (const cookie of hostCookies) {
+      await cookieStore!.delete({ name, domain: cookie.domain });
+    }
+
+    if (domainCookie) {
+      if (domainCookie.value !== currentValue) {
+        controller.setContext({ visitor_id: domainCookie.value });
+      }
+    } else {
+      Cookie.set(name, currentValue, { maxAge: MAX_AGE, domain });
+    }
+  } catch {
+    Cookie.set(name, currentValue, { maxAge: MAX_AGE, domain });
+  }
+}
+
 /**
  * Visitor Identity which can be used in Cookies
  * @public  */
@@ -19,14 +65,21 @@ export const visitorIdentity =
   ({ domain }: VisitorIdentityOptions = {}): Trackable.Manager =>
   controller => {
     if (typeof document === 'undefined') return;
-    const cookieOptions: Parameters<typeof Cookie.set>[2] = { maxAge: 60 * 60 * 24 * 365 * 5 };
-    if (domain) {
-      cookieOptions.domain = domain;
-    }
+
     let value = Cookie.get(COOKIE_NAME);
     if (!value) {
       value = uuid();
     }
-    Cookie.set(COOKIE_NAME, value, cookieOptions);
     controller.setContext({ visitor_id: value });
+
+    if (!domain) {
+      Cookie.set(COOKIE_NAME, value, { maxAge: MAX_AGE });
+      return;
+    }
+
+    if (typeof cookieStore !== 'undefined') {
+      migrateWithCookieStore(COOKIE_NAME, value, domain, controller);
+    } else {
+      Cookie.set(COOKIE_NAME, value, { maxAge: MAX_AGE, domain });
+    }
   };

--- a/packages/sdk/src/trackers/visitorId.ts
+++ b/packages/sdk/src/trackers/visitorId.ts
@@ -16,12 +16,12 @@ export type VisitorIdentityOptions = {
 interface CookieStoreEntry {
   name: string;
   value: string;
-  domain: string;
+  domain: string | null;
 }
 
 interface CookieStore {
   getAll(name: string): Promise<CookieStoreEntry[]>;
-  delete(options: { name: string; domain: string }): Promise<void>;
+  delete(nameOrOptions: string | { name: string; domain: string }): Promise<void>;
 }
 
 declare const cookieStore: CookieStore | undefined;
@@ -39,11 +39,15 @@ async function migrateWithCookieStore(
   try {
     const cookies = await cookieStore!.getAll(name);
     const normalizedDomain = normalizeDomain(domain);
-    const domainCookie = cookies.find(c => normalizeDomain(c.domain) === normalizedDomain);
+    const domainCookie = cookies.find(c => c.domain !== null && normalizeDomain(c.domain) === normalizedDomain);
     const hostCookies = cookies.filter(c => c !== domainCookie);
 
     for (const cookie of hostCookies) {
-      await cookieStore!.delete({ name, domain: cookie.domain });
+      if (cookie.domain !== null) {
+        await cookieStore!.delete({ name, domain: cookie.domain });
+      } else {
+        await cookieStore!.delete(name);
+      }
     }
 
     if (domainCookie) {

--- a/packages/sdk/src/trackers/visitorId.ts
+++ b/packages/sdk/src/trackers/visitorId.ts
@@ -53,7 +53,7 @@ async function migrateWithCookieStore(
     } else {
       Cookie.set(name, currentValue, { maxAge: MAX_AGE, domain });
     }
-  } catch {
+  } catch (_e) {
     Cookie.set(name, currentValue, { maxAge: MAX_AGE, domain });
   }
 }


### PR DESCRIPTION
## Summary
- Uses the [CookieStore API](https://developer.mozilla.org/en-US/docs/Web/API/CookieStore) to properly migrate host-scoped `cnfdVisitorId` cookies when `domain` is configured
- Detects existing domain cookies and preserves them instead of overwriting, preventing the visitor ID flip-flop across subdomains
- Falls back to simple domain cookie set when CookieStore is unavailable

## Context
Follow-up to #356. When a user has host-scoped cookies on multiple subdomains (e.g. `visitorId=x` on `a.acme.com` and `visitorId=y` on `b.acme.com`), the legacy `document.cookie` API can't distinguish host vs domain cookies — whichever subdomain is visited last overwrites the domain cookie. CookieStore's `getAll()` returns domain info, letting us preserve the first-set domain value.

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` — 168 tests pass (8 new for visitorId)
- [x] `yarn format:check` clean
- [x] `yarn bundle` — API report unchanged
- [ ] Manual: verify on HTTPS site with multiple subdomains

🤖 Generated with [Claude Code](https://claude.com/claude-code)