### PR TITLE
refactor(providers): derive provider options from ConfidenceOptions

### DIFF
--- a/api/openfeature-server-provider.d.ts
+++ b/api/openfeature-server-provider.d.ts
@@ -1,5 +1,5 @@
 import { Provider, ProviderMetadata, ProviderStatus, EvaluationContext, ResolutionDetails, JsonValue } from '@openfeature/server-sdk';
-import { FlagResolver, Confidence } from '@spotify-confidence/sdk';
+import { FlagResolver, ConfidenceOptions, Confidence } from '@spotify-confidence/sdk';
 
 /**
  * OpenFeature Provider for Confidence Server SDK
@@ -28,16 +28,7 @@ declare class ConfidenceServerProvider implements Provider {
 /**
  * Factory Options for Confidence Server Provider
  * @public */
-type ConfidenceProviderFactoryOptions = {
-    region?: 'eu' | 'us';
-    fetchImplementation?: typeof fetch;
-    clientSecret: string;
-    timeout: number;
-    /** Sets an alternative resolve url */
-    resolveBaseUrl?: string;
-    /** Sets an alternative apply url */
-    applyBaseUrl?: string;
-};
+type ConfidenceProviderFactoryOptions = Omit<ConfidenceOptions, 'environment' | 'library' | 'context'>;
 /**
  * Creates an OpenFeature-adhering Confidence Provider
  * @param options - Options for Confidence Provider

--- a/api/openfeature-web-provider.d.ts
+++ b/api/openfeature-web-provider.d.ts
@@ -1,5 +1,5 @@
 import { Provider, ProviderMetadata, OpenFeatureEventEmitter, EvaluationContext, ResolutionDetails, JsonValue } from '@openfeature/web-sdk';
-import { FlagResolver, Confidence } from '@spotify-confidence/sdk';
+import { FlagResolver, Confidence, ConfidenceOptions } from '@spotify-confidence/sdk';
 
 /**
  * OpenFeature Provider for Confidence Web SDK
@@ -35,16 +35,7 @@ declare class ConfidenceWebProvider implements Provider {
 /**
  * Factory Options for Confidence Web Provider
  * @public */
-type ConfidenceWebProviderOptions = {
-    region?: 'eu' | 'us';
-    fetchImplementation?: typeof fetch;
-    clientSecret: string;
-    timeout: number;
-    /** Sets an alternative resolve url */
-    resolveBaseUrl?: string;
-    /** Sets an alternative apply url */
-    applyBaseUrl?: string;
-};
+type ConfidenceWebProviderOptions = Omit<ConfidenceOptions, 'environment' | 'library' | 'context'>;
 /**
  * Creates an OpenFeature-adhering Confidence Provider
  * @param options - Options for Confidence Provider

--- a/packages/openfeature-server-provider/src/factory.ts
+++ b/packages/openfeature-server-provider/src/factory.ts
@@ -1,20 +1,11 @@
 import { Provider } from '@openfeature/server-sdk';
 import { ConfidenceServerProvider } from './ConfidenceServerProvider';
-import { Confidence } from '@spotify-confidence/sdk';
+import { Confidence, ConfidenceOptions } from '@spotify-confidence/sdk';
 
 /**
  * Factory Options for Confidence Server Provider
  * @public */
-export type ConfidenceProviderFactoryOptions = {
-  region?: 'eu' | 'us';
-  fetchImplementation?: typeof fetch;
-  clientSecret: string;
-  timeout: number;
-  /** Sets an alternative resolve url */
-  resolveBaseUrl?: string;
-  /** Sets an alternative apply url */
-  applyBaseUrl?: string;
-};
+export type ConfidenceProviderFactoryOptions = Omit<ConfidenceOptions, 'environment' | 'library' | 'context'>;
 
 /**
  * Creates an OpenFeature-adhering Confidence Provider

--- a/packages/openfeature-web-provider/src/factory.ts
+++ b/packages/openfeature-web-provider/src/factory.ts
@@ -1,20 +1,11 @@
 import { Provider } from '@openfeature/web-sdk';
 import { ConfidenceWebProvider } from './ConfidenceWebProvider';
-import { Confidence } from '@spotify-confidence/sdk';
+import { Confidence, ConfidenceOptions } from '@spotify-confidence/sdk';
 
 /**
  * Factory Options for Confidence Web Provider
  * @public */
-export type ConfidenceWebProviderOptions = {
-  region?: 'eu' | 'us';
-  fetchImplementation?: typeof fetch;
-  clientSecret: string;
-  timeout: number;
-  /** Sets an alternative resolve url */
-  resolveBaseUrl?: string;
-  /** Sets an alternative apply url */
-  applyBaseUrl?: string;
-};
+export type ConfidenceWebProviderOptions = Omit<ConfidenceOptions, 'environment' | 'library' | 'context'>;
 
 /**
  * Creates an OpenFeature-adhering Confidence Provider


### PR DESCRIPTION
## Summary
- Replace hand-written provider options types with `Omit<ConfidenceOptions, 'environment' | 'library' | 'context'>` in both web and server provider factories
- Eliminates type drift between `ConfidenceOptions` and provider options, so passing a `ConfidenceOptions` object to `createConfidenceWebProvider` / `createConfidenceServerProvider` just works
- All new `ConfidenceOptions` fields (e.g. `logger`, `cache`, `disableTelemetry`) are now automatically available through the provider factories

## Test plan
- [x] `yarn build` passes
- [x] All 159 tests pass
- [ ] Verify downstream consumers compile without changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)