### PR TITLE
fix: add csr packages to release-please

### DIFF
--- a/.github/workflows/Release-Please.yml
+++ b/.github/workflows/Release-Please.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Build
         shell: bash
         run: yarn bundle
+      - name: Build CSR
+        shell: bash
+        run: yarn build:csr
       - name: Publish sdk to NPM
         shell: bash
         working-directory: packages/sdk
@@ -70,6 +73,24 @@ jobs:
       - name: Publish openfeature-server-provider to NPM
         shell: bash
         working-directory: packages/openfeature-server-provider
+        run: |
+          yarn pack -o package.tgz
+          npm publish package.tgz
+      - name: Publish csr-common to NPM
+        shell: bash
+        working-directory: csr/csr-common
+        run: |
+          yarn pack -o package.tgz
+          npm publish package.tgz
+      - name: Publish csr-recorder to NPM
+        shell: bash
+        working-directory: csr/csr-recorder
+        run: |
+          yarn pack -o package.tgz
+          npm publish package.tgz
+      - name: Publish session-recording to NPM
+        shell: bash
+        working-directory: csr/session-recording
         run: |
           yarn pack -o package.tgz
           npm publish package.tgz

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,8 @@
   "packages/openfeature-server-provider": "0.3.18",
   "packages/openfeature-web-provider": "0.3.18",
   "packages/sdk": "0.3.18",
-  "packages/react": "0.2.17"
+  "packages/react": "0.2.17",
+  "csr/csr-common": "0.17.0",
+  "csr/csr-recorder": "0.17.0",
+  "csr/session-recording": "0.17.0"
 }

--- a/csr/csr-common/package.json
+++ b/csr/csr-common/package.json
@@ -30,6 +30,8 @@
     "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
     "type": "module",
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",

--- a/csr/csr-recorder/package.json
+++ b/csr/csr-recorder/package.json
@@ -19,6 +19,8 @@
     "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
     "type": "module",
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",

--- a/csr/session-recording/package.json
+++ b/csr/session-recording/package.json
@@ -20,6 +20,8 @@
     "src"
   ],
   "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
     "type": "module",
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -27,6 +27,24 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": ["src/Confidence.ts"]
+    },
+    "csr/csr-common": {
+      "component": "csr-common",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
+    },
+    "csr/csr-recorder": {
+      "component": "csr-recorder",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
+    },
+    "csr/session-recording": {
+      "component": "session-recording",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## Summary
- Adds `csr-common`, `csr-recorder`, and `session-recording` to release-please config and manifest
- Adds CSR build and publish steps to the release workflow

## Test plan
- [ ] CI passes
- [ ] Verify release-please picks up the new packages on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)