### PR TITLE
feat: add route parameterization for route change and meta events

### DIFF
--- a/csr/csr-recorder/README.md
+++ b/csr/csr-recorder/README.md
@@ -27,6 +27,34 @@ const stop = record(
 stop();
 ```
 
+## Route parameterization
+
+When `captureRouteChanges` is enabled (the default), recorded pathnames are automatically parameterized before being emitted. This replaces dynamic segments with named placeholders so that analytics can group routes by pattern rather than individual URLs.
+
+Default replacements:
+
+| Pattern                | Example                                | Replacement |
+| ---------------------- | -------------------------------------- | ----------- |
+| UUID                   | `550e8400-e29b-41d4-a716-446655440000` | `:uuid`     |
+| Numeric ID             | `123`                                  | `:id`       |
+| AIP-122 ID             | `cmvkznnjmbkc9rw2oxws`                 | `:id`       |
+| Hex string (20+ chars) | `507f1f77bcf86cd799439011`             | `:id`       |
+
+Provide a custom function to handle application-specific patterns:
+
+```typescript
+import { record, defaultParameterizeRoute } from '@spotify-confidence/csr-recorder';
+
+const stop = record(event => {}, {
+  parameterizeRoute: route => {
+    // Apply defaults first, then handle your own patterns
+    return defaultParameterizeRoute(route).replace(/\/teams\/[^/]+/, '/teams/:slug');
+  },
+});
+```
+
+The same parameterization is also applied to the `href` in rrweb Meta events.
+
 ## rrweb version
 
 This package pins `rrweb@^2.0.0-alpha.20`. The rrweb 2.x line is in alpha but is the version we've validated against. The recording engine is bundled — consumers do not need rrweb as a peer dependency.

--- a/csr/csr-recorder/README.md
+++ b/csr/csr-recorder/README.md
@@ -29,7 +29,7 @@ stop();
 
 ## Route parameterization
 
-When `captureRouteChanges` is enabled (the default), recorded pathnames are automatically parameterized before being emitted. This replaces dynamic segments with named placeholders so that analytics can group routes by pattern rather than individual URLs.
+Routes containing dynamic segments (such as IDs in the URL) are automatically normalized into patterns — for example, `/users/123/profile` becomes `/users/:id/profile`. This ensures that per-page metrics are grouped by route rather than by individual page visit, keeping dashboards meaningful and query performance fast.
 
 Default replacements:
 
@@ -40,7 +40,7 @@ Default replacements:
 | AIP-122 ID             | `cmvkznnjmbkc9rw2oxws`                 | `:id`       |
 | Hex string (20+ chars) | `507f1f77bcf86cd799439011`             | `:id`       |
 
-Provide a custom function to handle application-specific patterns:
+If your app uses URL patterns that aren't automatically detected, you can provide a custom `parameterizeRoute` function to control how routes are grouped:
 
 ```typescript
 import { record, defaultParameterizeRoute } from '@spotify-confidence/csr-recorder';

--- a/csr/csr-recorder/src/index.ts
+++ b/csr/csr-recorder/src/index.ts
@@ -9,3 +9,4 @@ export {
   DEFAULT_BLOCK_SELECTORS,
 } from './types';
 export { record } from './start-recording';
+export { defaultParameterizeRoute } from './route-parameterizer';

--- a/csr/csr-recorder/src/recorder-routing.test.ts
+++ b/csr/csr-recorder/src/recorder-routing.test.ts
@@ -8,10 +8,15 @@ class MockEngine implements RecordingEngine {
   private onEvent: ((event: RecordingEvent) => void) | null = null;
   startCalled = false;
   stopCalled = false;
+  /** Events emitted synchronously during start(), simulating rrweb behaviour. */
+  eventsOnStart: RecordingEvent[] = [];
 
   start(_config: unknown, onEvent: (event: RecordingEvent) => void): void {
     this.startCalled = true;
     this.onEvent = onEvent;
+    for (const event of this.eventsOnStart) {
+      onEvent(event);
+    }
   }
 
   stop(): void {
@@ -117,6 +122,22 @@ describe('Recorder route change capture', () => {
     recorder.stop();
   });
 
+  it('does not emit when parameterized routes are identical', () => {
+    const engine = new MockEngine();
+    const onEvent = vi.fn();
+    const recorder = new Recorder({ engine, onEvent });
+    recorder.start();
+
+    history.pushState({}, '', '/users/123');
+    history.pushState({}, '', '/users/456');
+
+    const events = routeChangeEvents(onEvent);
+    expect(events).toHaveLength(1);
+    expect(events[0].to).toBe('/users/:id');
+
+    recorder.stop();
+  });
+
   it('emits for popstate events', () => {
     const engine = new MockEngine();
     const onEvent = vi.fn();
@@ -136,6 +157,101 @@ describe('Recorder route change capture', () => {
     const allEvents = routeChangeEvents(onEvent);
     const popstateEvents = allEvents.filter(e => e.trigger === 'popstate');
     expect(popstateEvents.length).toBeGreaterThanOrEqual(1);
+
+    recorder.stop();
+  });
+
+  it('parameterizes routes by default', () => {
+    const engine = new MockEngine();
+    const onEvent = vi.fn();
+    const recorder = new Recorder({ engine, onEvent });
+    recorder.start();
+
+    history.pushState({}, '', '/users/123');
+
+    const events = routeChangeEvents(onEvent);
+    expect(events).toHaveLength(1);
+    expect(events[0].to).toBe('/users/:id');
+
+    recorder.stop();
+  });
+
+  it('parameterizes UUIDs by default', () => {
+    const engine = new MockEngine();
+    const onEvent = vi.fn();
+    const recorder = new Recorder({ engine, onEvent });
+    recorder.start();
+
+    history.pushState({}, '', '/items/550e8400-e29b-41d4-a716-446655440000');
+
+    const events = routeChangeEvents(onEvent);
+    expect(events).toHaveLength(1);
+    expect(events[0].to).toBe('/items/:uuid');
+
+    recorder.stop();
+  });
+
+  it('uses a custom parameterizeRoute when provided', () => {
+    const engine = new MockEngine();
+    const onEvent = vi.fn();
+    const recorder = new Recorder({ engine, onEvent });
+    recorder.start({
+      parameterizeRoute: route => route.replace(/\/users\/[^/]+/, '/users/:userId'),
+    });
+
+    history.pushState({}, '', '/users/alice');
+
+    const events = routeChangeEvents(onEvent);
+    expect(events).toHaveLength(1);
+    expect(events[0].to).toBe('/users/:userId');
+
+    recorder.stop();
+  });
+
+  it('parameterizes href in meta events emitted by the engine', () => {
+    const engine = new MockEngine();
+    engine.eventsOnStart = [
+      {
+        type: RecordingEventType.Meta,
+        timestamp: 1,
+        data: { href: 'https://example.com/users/123/settings', width: 1920, height: 1080 },
+      },
+    ];
+    const onEvent = vi.fn();
+    const recorder = new Recorder({ engine, onEvent });
+    recorder.start();
+
+    const metaEvents = (onEvent.mock.calls as [RecordingEvent][])
+      .map(([e]) => e)
+      .filter(e => e.type === RecordingEventType.Meta);
+
+    expect(metaEvents).toHaveLength(1);
+    expect((metaEvents[0].data as { href: string }).href).toBe('https://example.com/users/:id/settings');
+
+    recorder.stop();
+  });
+
+  it('parameterizes meta href using custom parameterizeRoute', () => {
+    const engine = new MockEngine();
+    engine.eventsOnStart = [
+      {
+        type: RecordingEventType.Meta,
+        timestamp: 1,
+        data: { href: 'https://example.com/teams/acme-corp/dashboard', width: 1920, height: 1080 },
+      },
+    ];
+    const onEvent = vi.fn();
+    const recorder = new Recorder({ engine, onEvent });
+    recorder.start({
+      parameterizeRoute: route => route.replace(/\/teams\/[^/]+/, '/teams/:slug'),
+    });
+
+    const metaEvents = (onEvent.mock.calls as [RecordingEvent][])
+      .map(([e]) => e)
+      .filter(e => e.type === RecordingEventType.Meta);
+
+    expect(metaEvents).toHaveLength(1);
+    expect((metaEvents[0].data as { href: string }).href).toBe('https://example.com/teams/:slug/dashboard');
 
     recorder.stop();
   });

--- a/csr/csr-recorder/src/recorder.ts
+++ b/csr/csr-recorder/src/recorder.ts
@@ -8,6 +8,7 @@ import {
 } from '@spotify-confidence/csr-common';
 import { RecorderOptions, RecorderState, RecordingConfig } from './types';
 import { RecordingEngine } from './engine';
+import { defaultParameterizeRoute } from './route-parameterizer';
 
 export class Recorder {
   private readonly engine: RecordingEngine;
@@ -20,6 +21,7 @@ export class Recorder {
   private originalPushState: typeof history.pushState | null = null;
   private originalReplaceState: typeof history.replaceState | null = null;
   private popstateHandler: (() => void) | null = null;
+  private parameterizeRoute!: (route: string) => string;
 
   constructor(options: RecorderOptions) {
     this.engine = options.engine;
@@ -35,7 +37,15 @@ export class Recorder {
       return;
     }
     this.state = RecorderState.Recording;
+    this.parameterizeRoute = config?.parameterizeRoute ?? defaultParameterizeRoute;
+
     this.engine.start(config ?? {}, event => {
+      if (event.type === RecordingEventType.Meta) {
+        const data = event.data as { href?: string };
+        if (typeof data?.href === 'string') {
+          event = { ...event, data: { ...data, href: this.parameterizeHref(data.href) } };
+        }
+      }
       this.onEvent(event);
     });
 
@@ -174,11 +184,24 @@ export class Recorder {
     };
   }
 
+  private parameterizeHref(href: string): string {
+    try {
+      const url = new URL(href);
+      url.pathname = this.parameterizeRoute(url.pathname);
+      return url.toString();
+    } catch (_e) {
+      return this.parameterizeRoute(href);
+    }
+  }
+
   private emitRouteChange(from: string, to: string, trigger: RouteChangeTrigger): void {
     if (from === to) return;
+    const paramFrom = this.parameterizeRoute(from);
+    const paramTo = this.parameterizeRoute(to);
+    if (paramFrom === paramTo) return;
     const data: RouteChangePluginData = {
       plugin: 'csr:routeChange',
-      payload: { from, to, trigger },
+      payload: { from: paramFrom, to: paramTo, trigger },
     };
     this.onEvent({
       type: RecordingEventType.Plugin,

--- a/csr/csr-recorder/src/route-parameterizer.test.ts
+++ b/csr/csr-recorder/src/route-parameterizer.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { defaultParameterizeRoute } from './route-parameterizer';
+
+describe('defaultParameterizeRoute', () => {
+  it('leaves static routes unchanged', () => {
+    expect(defaultParameterizeRoute('/users/settings')).toBe('/users/settings');
+  });
+
+  it('replaces numeric IDs', () => {
+    expect(defaultParameterizeRoute('/users/123')).toBe('/users/:id');
+    expect(defaultParameterizeRoute('/users/123/posts/456')).toBe('/users/:id/posts/:id');
+  });
+
+  it('replaces UUIDs', () => {
+    expect(defaultParameterizeRoute('/users/550e8400-e29b-41d4-a716-446655440000')).toBe('/users/:uuid');
+  });
+
+  it('replaces uppercase UUIDs', () => {
+    expect(defaultParameterizeRoute('/users/550E8400-E29B-41D4-A716-446655440000')).toBe('/users/:uuid');
+  });
+
+  it('replaces long hex strings (MongoDB ObjectIDs)', () => {
+    expect(defaultParameterizeRoute('/items/507f1f77bcf86cd799439011')).toBe('/items/:id');
+  });
+
+  it('handles mixed segments', () => {
+    expect(defaultParameterizeRoute('/org/550e8400-e29b-41d4-a716-446655440000/users/42/profile')).toBe(
+      '/org/:uuid/users/:id/profile',
+    );
+  });
+
+  it('preserves root path', () => {
+    expect(defaultParameterizeRoute('/')).toBe('/');
+  });
+
+  it('preserves empty string', () => {
+    expect(defaultParameterizeRoute('')).toBe('');
+  });
+
+  it('does not replace short hex strings', () => {
+    expect(defaultParameterizeRoute('/features/abcdef')).toBe('/features/abcdef');
+  });
+
+  it('does not replace words that look vaguely hex-ish', () => {
+    expect(defaultParameterizeRoute('/dashboard/feed')).toBe('/dashboard/feed');
+  });
+
+  it('handles trailing slash', () => {
+    expect(defaultParameterizeRoute('/users/123/')).toBe('/users/:id/');
+  });
+
+  it('replaces AIP-122 generated IDs', () => {
+    expect(defaultParameterizeRoute('/workflows/abtest/instances/cmvkznnjmbkc9rw2oxws/report')).toBe(
+      '/workflows/abtest/instances/:id/report',
+    );
+  });
+
+  it('replaces multiple AIP-122 IDs', () => {
+    expect(defaultParameterizeRoute('/admin/workflows/a0smva5nxuhv4yts6pax/instances/cmvkznnjmbkc9rw2oxws')).toBe(
+      '/admin/workflows/:id/instances/:id',
+    );
+  });
+
+  it('does not replace short lowercase strings as AIP-122', () => {
+    expect(defaultParameterizeRoute('/workflows/abtest')).toBe('/workflows/abtest');
+  });
+
+  it('replaces segments containing embedded hex IDs', () => {
+    expect(defaultParameterizeRoute('/items/prefix507f1f77bcf86cd799439011suffix')).toBe('/items/:id');
+  });
+
+  it('replaces MD5 hashes', () => {
+    expect(defaultParameterizeRoute('/cache/d41d8cd98f00b204e9800998ecf8427e')).toBe('/cache/:id');
+  });
+});

--- a/csr/csr-recorder/src/route-parameterizer.ts
+++ b/csr/csr-recorder/src/route-parameterizer.ts
@@ -1,0 +1,20 @@
+const SEGMENT_PATTERNS: Array<{ pattern: RegExp; replacement: string }> = [
+  { pattern: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, replacement: ':uuid' },
+  { pattern: /^\d+$/, replacement: ':id' },
+  // AIP-122 generated IDs: 20-char lowercase alphanumeric starting with a letter
+  { pattern: /^[a-z][a-z0-9]{19}$/, replacement: ':id' },
+  { pattern: /[0-9a-f]{20}/i, replacement: ':id' },
+];
+
+export function defaultParameterizeRoute(route: string): string {
+  return route
+    .split('/')
+    .map(segment => {
+      if (!segment) return segment;
+      for (const { pattern, replacement } of SEGMENT_PATTERNS) {
+        if (pattern.test(segment)) return replacement;
+      }
+      return segment;
+    })
+    .join('/');
+}

--- a/csr/csr-recorder/src/types.ts
+++ b/csr/csr-recorder/src/types.ts
@@ -57,11 +57,14 @@ export interface RecordingConfig {
   captureRouteChanges?: boolean;
   /**
    * Transform a raw pathname into a route pattern before it is emitted in
-   * route-change events.
+   * route-change and Meta events. For example, `/users/123/profile` becomes
+   * `/users/:id/profile`. This ensures per-page metrics are grouped by route
+   * rather than by individual page visit.
    *
    * The default implementation replaces common dynamic segments:
    * - UUIDs → `:uuid`
    * - Numeric IDs → `:id`
+   * - AIP-122 IDs → `:id`
    * - Long hex strings (20+ chars, e.g. MongoDB ObjectIDs) → `:id`
    *
    * Provide a custom function to handle application-specific patterns.

--- a/csr/csr-recorder/src/types.ts
+++ b/csr/csr-recorder/src/types.ts
@@ -55,6 +55,19 @@ export interface RecordingConfig {
    * hashes are stripped.
    */
   captureRouteChanges?: boolean;
+  /**
+   * Transform a raw pathname into a route pattern before it is emitted in
+   * route-change events.
+   *
+   * The default implementation replaces common dynamic segments:
+   * - UUIDs → `:uuid`
+   * - Numeric IDs → `:id`
+   * - Long hex strings (20+ chars, e.g. MongoDB ObjectIDs) → `:id`
+   *
+   * Provide a custom function to handle application-specific patterns.
+   * Import `defaultParameterizeRoute` to compose with the built-in rules.
+   */
+  parameterizeRoute?: (route: string) => string;
 }
 
 export enum RecorderState {

--- a/csr/session-recording/README.md
+++ b/csr/session-recording/README.md
@@ -92,6 +92,25 @@ const recorder = initSessionRecorder({
 });
 ```
 
+## Route parameterization
+
+When route change capture is enabled (the default), recorded pathnames are automatically parameterized — dynamic segments like UUIDs, numeric IDs, and hex strings are replaced with placeholders (`:uuid`, `:id`). This groups routes by pattern rather than individual URL, keeping analytics clean and avoiding high-cardinality data.
+
+Provide a custom `parameterizeRoute` to handle application-specific patterns:
+
+```typescript
+import { defaultParameterizeRoute } from '@spotify-confidence/csr-recorder';
+
+const recorder = initSessionRecorder({
+  clientSecret: '<your-client-secret>',
+  parameterizeRoute: route => {
+    return defaultParameterizeRoute(route).replace(/\/teams\/[^/]+/, '/teams/:slug');
+  },
+});
+```
+
+See the [`@spotify-confidence/csr-recorder` README](../csr-recorder/README.md#route-parameterization) for the full list of default patterns.
+
 ## Manual mode
 
 Use `manual` mode to control when recording starts — useful for gating on user consent or feature flags.

--- a/csr/session-recording/README.md
+++ b/csr/session-recording/README.md
@@ -94,9 +94,9 @@ const recorder = initSessionRecorder({
 
 ## Route parameterization
 
-When route change capture is enabled (the default), recorded pathnames are automatically parameterized — dynamic segments like UUIDs, numeric IDs, and hex strings are replaced with placeholders (`:uuid`, `:id`). This groups routes by pattern rather than individual URL, keeping analytics clean and avoiding high-cardinality data.
+Routes containing dynamic segments (such as IDs in the URL) are automatically normalized into patterns — for example, `/users/123/profile` becomes `/users/:id/profile`. This ensures that per-page metrics are grouped by route rather than by individual page visit, keeping dashboards meaningful and query performance fast.
 
-Provide a custom `parameterizeRoute` to handle application-specific patterns:
+If your app uses URL patterns that aren't automatically detected, you can provide a custom `parameterizeRoute` function to control how routes are grouped:
 
 ```typescript
 import { defaultParameterizeRoute } from '@spotify-confidence/csr-recorder';

--- a/csr/session-recording/src/index.ts
+++ b/csr/session-recording/src/index.ts
@@ -30,6 +30,15 @@ export interface InitSessionRecorderOptions {
   captureNetworkRequests?: boolean;
   /** Capture client-side route changes (pathname only). Defaults to `true`. */
   captureRouteChanges?: boolean;
+  /**
+   * Transform a raw pathname into a route pattern before it is emitted in
+   * route-change events. Defaults to replacing UUIDs, numeric IDs, AIP-122
+   * IDs, and long hex strings with named placeholders.
+   *
+   * Import `defaultParameterizeRoute` from `@spotify-confidence/csr-recorder`
+   * to compose with the built-in rules.
+   */
+  parameterizeRoute?: (route: string) => string;
   /** Backend base URL. Defaults to the Confidence production endpoint. */
   apiUrl?: string;
   /** WebSocket ingest URL. Defaults to the Confidence production endpoint. */
@@ -97,6 +106,7 @@ export function initSessionRecorder(options: InitSessionRecorderOptions): Sessio
     captureConsoleLogs: options.captureConsoleLogs,
     captureNetworkRequests: options.captureNetworkRequests,
     captureRouteChanges: options.captureRouteChanges,
+    parameterizeRoute: options.parameterizeRoute,
   };
 
   async function initAndRecord(forceRecord: boolean) {

--- a/csr/session-recording/src/index.ts
+++ b/csr/session-recording/src/index.ts
@@ -32,8 +32,9 @@ export interface InitSessionRecorderOptions {
   captureRouteChanges?: boolean;
   /**
    * Transform a raw pathname into a route pattern before it is emitted in
-   * route-change events. Defaults to replacing UUIDs, numeric IDs, AIP-122
-   * IDs, and long hex strings with named placeholders.
+   * route-change and Meta events. For example, `/users/123/profile` becomes
+   * `/users/:id/profile`. This ensures per-page metrics are grouped by route
+   * rather than by individual page visit.
    *
    * Import `defaultParameterizeRoute` from `@spotify-confidence/csr-recorder`
    * to compose with the built-in rules.


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

Replace dynamic pathname segments (UUIDs, numeric IDs, AIP-122 IDs, hex strings) with named placeholders before emitting route-change and rrweb Meta events. This reduces cardinality in analytics pipelines and avoids leaking user-specific IDs into recorded events.

Adds a `parameterizeRoute` config option on both `RecordingConfig` and `InitSessionRecorderOptions` so consumers can provide custom patterns. Exports `defaultParameterizeRoute` for composition.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing
- [x] Relevant documentation updated
- [x] linter/style run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [x] Tested in a corresponding example app
