### PR TITLE
ci: update release-please-action from v3 to v4.1.1

### DIFF
--- a/.github/workflows/Release-Please.yml
+++ b/.github/workflows/Release-Please.yml
@@ -24,13 +24,12 @@ jobs:
       csr-recorder-release_created: ${{ steps.release.outputs['csr/csr-recorder--release_created'] }}
       session-recording-release_created: ${{ steps.release.outputs['csr/session-recording--release_created'] }}
     steps:
-      - uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3
+      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1
         id: release
         with:
-          command: manifest
           token: ${{secrets.GITHUB_TOKEN}}
-          default-branch: main
-          monorepo-tags: true
+          target-branch: main
+          include-component-in-tag: true
       - name: Debug release-please outputs
         shell: bash
         run: echo '${{ toJSON(steps.release.outputs) }}'


### PR DESCRIPTION
## Summary
- Upgrades `google-github-actions/release-please-action` from v3 to v4.1.1 to resolve Node.js 20 deprecation (enforced June 16, 2026)
- Adapts workflow inputs to v4 API: removes `command`, renames `default-branch` → `target-branch`, `monorepo-tags` → `include-component-in-tag`

## Test plan
- [ ] Verify release-please PR creation still works on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)