### PR TITLE
docs: add session recording packages to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](https://img.shields.io/badge/lifecycle-beta-a0c3d2.svg)
 
-JavaScript SDKs for [Confidence](https://confidence.spotify.com/).
+Frontend JavaScript SDKs for [Confidence](https://confidence.spotify.com/).
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -12,22 +12,22 @@ Feature flag resolution via [OpenFeature](https://github.com/open-feature/js-sdk
 
 > **💡 For server-side use cases**, consider the [Confidence Local Resolver Provider for JavaScript](https://github.com/spotify/confidence-resolver/tree/main/openfeature-provider/js), which evaluates flags locally via WebAssembly for increased resilience and lower latency.
 
-| Package                                                                 | Description                                               |
-| ----------------------------------------------------------------------- | --------------------------------------------------------- |
-| [`openfeature-server-provider`](./packages/openfeature-server-provider) | OpenFeature provider for server-side environments         |
-| [`openfeature-web-provider`](./packages/openfeature-web-provider)       | OpenFeature provider for client-side web applications     |
-| [`sdk`](./packages/sdk)                                                 | Core SDK for flag resolution, context, and tracking       |
-| [`react`](./packages/react)                                             | React hooks and providers for client-side applications    |
+| Package                                                                 | Description                                            |
+| ----------------------------------------------------------------------- | ------------------------------------------------------ |
+| [`openfeature-server-provider`](./packages/openfeature-server-provider) | OpenFeature provider for server-side environments      |
+| [`openfeature-web-provider`](./packages/openfeature-web-provider)       | OpenFeature provider for client-side web applications  |
+| [`sdk`](./packages/sdk)                                                 | Core SDK for flag resolution, context, and tracking    |
+| [`react`](./packages/react)                                             | React hooks and providers for client-side applications |
 
 ### Session Recording
 
 Browser SDK for capturing user sessions and streaming them to Confidence for replay and analysis.
 
-| Package                                                                 | Description                                              |
-| ----------------------------------------------------------------------- | -------------------------------------------------------- |
-| [`session-recording`](./csr/session-recording)                          | Session recording SDK — start here                       |
-| [`csr-recorder`](./csr/csr-recorder)                                    | Low-level recording engine (internal)                    |
-| [`csr-common`](./csr/csr-common)                                        | Shared types, events, and transport utilities (internal) |
+| Package                                        | Description                                              |
+| ---------------------------------------------- | -------------------------------------------------------- |
+| [`session-recording`](./csr/session-recording) | Session recording SDK — start here                       |
+| [`csr-recorder`](./csr/csr-recorder)           | Low-level recording engine (internal)                    |
+| [`csr-common`](./csr/csr-common)               | Shared types, events, and transport utilities (internal) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,32 @@
 
 ![](https://img.shields.io/badge/lifecycle-beta-a0c3d2.svg)
 
-JavaScript implementation of the [Confidence](https://confidence.spotify.com/) SDK and the Confidence OpenFeature provider, to be used in conjunction wth the [OpenFeature SDK](https://github.com/open-feature/js-sdk).
-
-> **💡 For server-side use cases**, consider the [Confidence Local Resolver Provider for JavaScript](https://github.com/spotify/confidence-resolver/tree/main/openfeature-provider/js), which evaluates flags locally via WebAssembly for increased resilience and lower latency.
+JavaScript SDKs for [Confidence](https://confidence.spotify.com/).
 
 ## Overview
 
-This monorepo contains four packages:
+### Feature Flags
 
-| Package                                                                 | Description                                                    |
-| ----------------------------------------------------------------------- | -------------------------------------------------------------- |
-| [`openfeature-server-provider`](./packages/openfeature-server-provider) | OpenFeature provider for server-side environments              |
-| [`openfeature-web-provider`](./packages/openfeature-web-provider)       | OpenFeature provider for client-side web applications          |
-| [`sdk`](./packages/sdk)                                                 | Core Confidence SDK for flag resolution, context, and tracking |
-| [`react`](./packages/react)                                             | React hooks and providers for client-side applications         |
+Feature flag resolution via [OpenFeature](https://github.com/open-feature/js-sdk) or the standalone Confidence SDK.
 
-Read more about the packages in their respective docs.
+> **💡 For server-side use cases**, consider the [Confidence Local Resolver Provider for JavaScript](https://github.com/spotify/confidence-resolver/tree/main/openfeature-provider/js), which evaluates flags locally via WebAssembly for increased resilience and lower latency.
+
+| Package                                                                 | Description                                               |
+| ----------------------------------------------------------------------- | --------------------------------------------------------- |
+| [`openfeature-server-provider`](./packages/openfeature-server-provider) | OpenFeature provider for server-side environments         |
+| [`openfeature-web-provider`](./packages/openfeature-web-provider)       | OpenFeature provider for client-side web applications     |
+| [`sdk`](./packages/sdk)                                                 | Core SDK for flag resolution, context, and tracking       |
+| [`react`](./packages/react)                                             | React hooks and providers for client-side applications    |
+
+### Session Recording
+
+Browser SDK for capturing user sessions and streaming them to Confidence for replay and analysis.
+
+| Package                                                       | Description                                                       |
+| ------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [`session-recording`](./csr/session-recording)                | Session recording SDK — start here                                |
+| [`csr-recorder`](./csr/csr-recorder)                          | Low-level recording engine (internal)                             |
+| [`csr-common`](./csr/csr-common)                              | Shared types, events, and transport utilities (internal)          |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Feature flag resolution via [OpenFeature](https://github.com/open-feature/js-sdk
 
 Browser SDK for capturing user sessions and streaming them to Confidence for replay and analysis.
 
-| Package                                                       | Description                                                       |
-| ------------------------------------------------------------- | ----------------------------------------------------------------- |
-| [`session-recording`](./csr/session-recording)                | Session recording SDK — start here                                |
-| [`csr-recorder`](./csr/csr-recorder)                          | Low-level recording engine (internal)                             |
-| [`csr-common`](./csr/csr-common)                              | Shared types, events, and transport utilities (internal)          |
+| Package                                                                 | Description                                              |
+| ----------------------------------------------------------------------- | -------------------------------------------------------- |
+| [`session-recording`](./csr/session-recording)                          | Session recording SDK — start here                       |
+| [`csr-recorder`](./csr/csr-recorder)                                    | Low-level recording engine (internal)                    |
+| [`csr-common`](./csr/csr-common)                                        | Shared types, events, and transport utilities (internal) |
 
 ---
 

--- a/csr/session-recording/README.md
+++ b/csr/session-recording/README.md
@@ -92,6 +92,39 @@ const recorder = initSessionRecorder({
 });
 ```
 
+## Using with the Confidence flags SDK
+
+If you use both session recording and the Confidence SDK (or an OpenFeature provider) for feature flags, keep the contexts aligned. The Confidence backend uses the same context to target recording rules and flag rules, so matching values let you set up policies like "record sessions for users in the `beta` environment" or "only record premium users" without surprises.
+
+```typescript
+import Confidence from '@spotify-confidence/sdk';
+import { initSessionRecorder } from '@spotify-confidence/session-recording';
+
+const targetingKey = 'user-42';
+const context = {
+  environment: 'production',
+  plan: 'premium',
+};
+
+const confidence = Confidence.create({
+  clientSecret: '<your-client-secret>',
+  environment: 'client',
+  timeout: 1000,
+});
+confidence.setContext({
+  targeting_key: targetingKey,
+  ...context,
+});
+
+const recorder = initSessionRecorder({
+  clientSecret: '<your-client-secret>',
+  targetingKey,
+  context,
+});
+```
+
+The key thing is that `targetingKey` and any context fields you use for targeting should carry the same values in both SDKs.
+
 ## Route parameterization
 
 Routes containing dynamic segments (such as IDs in the URL) are automatically normalized into patterns — for example, `/users/123/profile` becomes `/users/:id/profile`. This ensures that per-page metrics are grouped by route rather than by individual page visit, keeping dashboards meaningful and query performance fast.

--- a/csr/session-recording/README.md
+++ b/csr/session-recording/README.md
@@ -94,36 +94,7 @@ const recorder = initSessionRecorder({
 
 ## Using with the Confidence flags SDK
 
-If you use both session recording and the Confidence SDK (or an OpenFeature provider) for feature flags, keep the contexts aligned. The Confidence backend uses the same context to target recording rules and flag rules, so matching values let you set up policies like "record sessions for users in the `beta` environment" or "only record premium users" without surprises.
-
-```typescript
-import Confidence from '@spotify-confidence/sdk';
-import { initSessionRecorder } from '@spotify-confidence/session-recording';
-
-const targetingKey = 'user-42';
-const context = {
-  environment: 'production',
-  plan: 'premium',
-};
-
-const confidence = Confidence.create({
-  clientSecret: '<your-client-secret>',
-  environment: 'client',
-  timeout: 1000,
-});
-confidence.setContext({
-  targeting_key: targetingKey,
-  ...context,
-});
-
-const recorder = initSessionRecorder({
-  clientSecret: '<your-client-secret>',
-  targetingKey,
-  context,
-});
-```
-
-The key thing is that `targetingKey` and any context fields you use for targeting should carry the same values in both SDKs.
+If you use both session recording and the Confidence SDK (or an OpenFeature provider) for feature flags, try your best to keep the contexts aligned. Aligning the contexts will make sense when using the Confidence app to set up targeting on recording rules and flag rules. Matching contexts will let you set up policies like "record sessions for users in the `beta` environment" or "only record premium users" without surprises.
 
 ## Route parameterization
 


### PR DESCRIPTION
## Summary
- Restructured the README overview to group packages by capability (Feature Flags, Session Recording) instead of a flat list
- Added the three CSR packages (`session-recording`, `csr-recorder`, `csr-common`) that were missing from the landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)