### PR TITLE
fix(csr): use workspace:* for inter-package deps

### DIFF
--- a/csr/csr-recorder/package.json
+++ b/csr/csr-recorder/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@rrweb/rrweb-plugin-console-record": "^2.0.1",
-    "@spotify-confidence/csr-common": "workspace:^",
+    "@spotify-confidence/csr-common": "workspace:*",
     "rrweb": "^2.0.1"
   }
 }

--- a/csr/session-recording/package.json
+++ b/csr/session-recording/package.json
@@ -35,7 +35,7 @@
     }
   },
   "dependencies": {
-    "@spotify-confidence/csr-common": "workspace:^",
-    "@spotify-confidence/csr-recorder": "workspace:^"
+    "@spotify-confidence/csr-common": "workspace:*",
+    "@spotify-confidence/csr-recorder": "workspace:*"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5130,7 +5130,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@spotify-confidence/csr-common@workspace:^, @spotify-confidence/csr-common@workspace:csr/csr-common":
+"@spotify-confidence/csr-common@workspace:*, @spotify-confidence/csr-common@workspace:csr/csr-common":
   version: 0.0.0-use.local
   resolution: "@spotify-confidence/csr-common@workspace:csr/csr-common"
   dependencies:
@@ -5138,12 +5138,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@spotify-confidence/csr-recorder@workspace:^, @spotify-confidence/csr-recorder@workspace:csr/csr-recorder":
+"@spotify-confidence/csr-recorder@workspace:*, @spotify-confidence/csr-recorder@workspace:csr/csr-recorder":
   version: 0.0.0-use.local
   resolution: "@spotify-confidence/csr-recorder@workspace:csr/csr-recorder"
   dependencies:
     "@rrweb/rrweb-plugin-console-record": "npm:^2.0.1"
-    "@spotify-confidence/csr-common": "workspace:^"
+    "@spotify-confidence/csr-common": "workspace:*"
     rrweb: "npm:^2.0.1"
   languageName: unknown
   linkType: soft
@@ -5215,8 +5215,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@spotify-confidence/session-recording@workspace:csr/session-recording"
   dependencies:
-    "@spotify-confidence/csr-common": "workspace:^"
-    "@spotify-confidence/csr-recorder": "workspace:^"
+    "@spotify-confidence/csr-common": "workspace:*"
+    "@spotify-confidence/csr-recorder": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary
Fixes the release-please PR (#382) failing CI with `YN0028: The lockfile would have been modified by this install, which is explicitly forbidden`.

### Root cause

The `node-workspace` plugin in release-please <16.12.0 rewrote `workspace:` protocol
dependencies to concrete npm versions (e.g. `workspace:^` → `0.18.0`), making
`yarn.lock` stale. Yarn 4's hardened mode (auto-enabled on public repo PRs) then
rejected the install.

This was fixed upstream in [googleapis/release-please#2281](https://github.com/googleapis/release-please/pull/2281)
(v16.12.0, June 2024) — dependencies using a protocol specifier (`workspace:`, `file:`,
etc.) are now left untouched.

### Why it never happened before

Prior csr releases were patch bumps (0.17.x → 0.17.y) where the caret range from
`workspace:^` still matched. PR #381 was the first breaking change (0.17.3 → 0.18.0),
triggering the rewrite for the first time. The `packages/` workspace was never affected
because `sdk` has only had patch bumps (0.3.x).

### Changes

1. **Upgrade release-please-action** from the archived `google-github-actions/release-please-action@v4.1.1`
   (bundling release-please ~16.10) to `googleapis/release-please-action@v5.0.0`
   (bundling release-please ~17.6) — past the fix.

2. **`workspace:^` → `workspace:*`** in csr inter-package deps — matches `packages/`
   convention. These packages are always released together and consumers only install
   `session-recording`, so exact version pinning at publish time is the right fit.

## Test plan
- [x] `yarn install` succeeds and lockfile is clean
- [ ] CI passes
- [ ] After merge, release-please regenerates #382 without rewriting `workspace:*` deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)