### PR TITLE
fix(ci): upgrade release-please-action to v5.0.0

### DIFF
--- a/.github/workflows/Release-Please.yml
+++ b/.github/workflows/Release-Please.yml
@@ -24,7 +24,7 @@ jobs:
       csr-recorder-release_created: ${{ steps.release.outputs['csr/csr-recorder--release_created'] }}
       session-recording-release_created: ${{ steps.release.outputs['csr/session-recording--release_created'] }}
     steps:
-      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Summary
Migrates from the archived `google-github-actions/release-please-action@v4.1.1`
to `googleapis/release-please-action@v5.0.0`.

The old action bundled release-please ~16.10, which had a bug where the
`node-workspace` plugin rewrote `workspace:` protocol dependencies to concrete
npm versions in release PRs — breaking `yarn.lock` under Yarn 4's hardened mode.

Fixed upstream in [googleapis/release-please#2281](https://github.com/googleapis/release-please/pull/2281)
(v16.12.0). The new action bundles release-please ~17.6.

Fixes #382.

## Test plan
- [ ] CI passes
- [ ] After merge, release-please regenerates #382 without rewriting `workspace:*` deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)