### PR TITLE
fix(csr-common): redact session_token from debug logs

### DIFF
--- a/csr/csr-common/src/uploader/worker/csr-client.test.ts
+++ b/csr/csr-common/src/uploader/worker/csr-client.test.ts
@@ -95,6 +95,18 @@ describe('CsrClient.openTransport', () => {
     await expect(client.openTransport('tok')).resolves.toBeDefined();
   });
 
+  it('redacts session_token from debug log', async () => {
+    installMockWsServer('wss://api/sessions/stream?session_token=secret-tok');
+
+    const logs: string[] = [];
+    const client = new CsrClient('https://api', 'secret', undefined, undefined, msg => logs.push(msg));
+    await client.openTransport('secret-tok');
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toContain('session_token=[REDACTED]');
+    expect(logs[0]).not.toContain('secret-tok');
+  });
+
   it('URL-encodes the session token', async () => {
     installMockWsServer('wss://api/sessions/stream?session_token=tok%2Fwith%3Dspecials');
 

--- a/csr/csr-common/src/uploader/worker/csr-client.ts
+++ b/csr/csr-common/src/uploader/worker/csr-client.ts
@@ -47,7 +47,7 @@ export class CsrClient implements Client {
     const wsBase = this.websocketUrl ?? `${this.toWsScheme(this.trimSlash(this.apiUrl))}/sessions/stream`;
     const sep = wsBase.includes('?') ? '&' : '?';
     const url = `${wsBase}${sep}session_token=${encodeURIComponent(sessionToken)}`;
-    this.log(`WebSocket connect ${url}`);
+    this.log(`WebSocket connect ${url.replace(/session_token=[^&]*/, 'session_token=[REDACTED]')}`);
     const transport = new WebSocketTransport(url);
     await transport.ready();
     return transport;


### PR DESCRIPTION
## Summary
- Redacts `session_token` from WebSocket URL in CSR debug logs to prevent credential leakage when `CSR_DEBUG` is enabled.

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)