### PR TITLE
fix(sdk): use sendBeacon for visibilitychange flush

### DIFF
--- a/packages/sdk/src/EventSenderEngine.ts
+++ b/packages/sdk/src/EventSenderEngine.ts
@@ -81,7 +81,7 @@ export class EventSenderEngine {
     if (typeof document !== 'undefined') {
       document.addEventListener('visibilitychange', () => {
         if (document.visibilityState === 'hidden') {
-          this.flush({ keepalive: true });
+          this.beaconFlush();
         }
       });
     }
@@ -146,6 +146,32 @@ export class EventSenderEngine {
     if (this.pendingFlush) {
       clearTimeout(this.pendingFlush);
       this.pendingFlush = undefined;
+    }
+  }
+
+  private beaconFlush(): void {
+    this.clearPendingFlush();
+    const batchSize = Math.min(this.writeQueue.length, this.maxBatchSize);
+    if (batchSize === 0) return;
+
+    if (typeof navigator === 'undefined' || typeof navigator.sendBeacon !== 'function') {
+      this.flush({ keepalive: true });
+      return;
+    }
+
+    const events = this.writeQueue.slice(0, batchSize);
+    const body = JSON.stringify({
+      clientSecret: this.clientSecret,
+      sendTime: new Date().toISOString(),
+      events: events.map(e => ({ ...e, eventDefinition: `eventDefinitions/${e.eventDefinition}` })),
+    });
+    const queued = navigator.sendBeacon(this.publishUrl, new Blob([body], { type: 'application/json' }));
+    if (queued) {
+      this.writeQueue.splice(0, batchSize);
+      this.logger.info?.('Confidence: beaconed %i events', batchSize);
+    } else {
+      this.logger.warn?.('Confidence: sendBeacon rejected, falling back to fetch');
+      this.flush({ keepalive: true });
     }
   }
 

--- a/packages/sdk/src/EventSenderEngine.ts
+++ b/packages/sdk/src/EventSenderEngine.ts
@@ -30,6 +30,10 @@ export interface EventSenderEngineOptions {
   logger: Logger;
 }
 
+// sendBeacon has a ~64KB payload limit shared with keepalive fetches.
+// Cap the unload batch well below that to maximize delivery success.
+const BEACON_MAX_BATCH_SIZE = 25;
+
 export class EventSenderEngine {
   private readonly writeQueue: Event[] = [];
   private readonly flushTimeoutMilliseconds: number;
@@ -149,9 +153,12 @@ export class EventSenderEngine {
     }
   }
 
+  // Bypasses fetchImplementation intentionally: sendBeacon must serialize and
+  // enqueue synchronously during page unload — the async FetchBuilder chain
+  // cannot guarantee completion before the page is discarded.
   private beaconFlush(): void {
     this.clearPendingFlush();
-    const batchSize = Math.min(this.writeQueue.length, this.maxBatchSize);
+    const batchSize = Math.min(this.writeQueue.length, this.maxBatchSize, BEACON_MAX_BATCH_SIZE);
     if (batchSize === 0) return;
 
     if (typeof navigator === 'undefined' || typeof navigator.sendBeacon !== 'function') {

--- a/packages/sdk/src/EventSenderEngine.visibilitychange.test.ts
+++ b/packages/sdk/src/EventSenderEngine.visibilitychange.test.ts
@@ -16,8 +16,16 @@ describe('EventSenderEngine visibilitychange', () => {
     return new Response(JSON.stringify({ errors: [] }));
   });
 
-  it('should flush with keepalive when document becomes hidden', async () => {
-    const engine = new EventSenderEngine({
+  let mockSendBeacon: jest.Mock;
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+    mockSendBeacon = jest.fn().mockReturnValue(true);
+    Object.defineProperty(navigator, 'sendBeacon', { value: mockSendBeacon, configurable: true, writable: true });
+  });
+
+  function createEngine(overrides?: Partial<ConstructorParameters<typeof EventSenderEngine>[0]>) {
+    return new EventSenderEngine({
       clientSecret: 'my_secret',
       maxBatchSize: BATCH_SIZE,
       flushTimeoutMilliseconds: FLUSH_TIMEOUT,
@@ -25,31 +33,95 @@ describe('EventSenderEngine visibilitychange', () => {
       region: 'eu',
       maxOpenRequests: MAX_OPEN_REQUESTS,
       logger: {},
+      ...overrides,
     });
-    const uploadSpy = jest.spyOn(engine, 'upload');
-    engine.send({ value: 1 }, 'my_event');
+  }
 
-    expect(uploadSpy).not.toHaveBeenCalled();
+  it('should use sendBeacon when document becomes hidden', async () => {
+    const engine = createEngine();
+    engine.send({ value: 1 }, 'my_event');
 
     jest.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
     document.dispatchEvent(new Event('visibilitychange'));
 
+    expect(mockSendBeacon).toHaveBeenCalledTimes(1);
+    expect(mockSendBeacon).toHaveBeenCalledWith('https://events.eu.confidence.dev/v1/events:publish', expect.any(Blob));
+
+    const blob: Blob = mockSendBeacon.mock.calls[0][1];
+    expect(blob.type).toBe('application/json');
+    const body = JSON.parse(
+      await new Promise<string>(resolve => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.readAsText(blob);
+      }),
+    );
+    expect(body.clientSecret).toBe('my_secret');
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].eventDefinition).toBe('eventDefinitions/my_event');
+    expect(body.events[0].payload).toEqual({ context: { value: 1 } });
+
+    await jest.runAllTimersAsync();
+  });
+
+  it('should remove events from queue after successful beacon', async () => {
+    const engine = createEngine();
+    engine.send({ value: 1 }, 'my_event');
+
+    jest.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(mockSendBeacon).toHaveBeenCalledTimes(1);
+
+    // Queue should be empty — a subsequent flush should be a no-op
+    const flushResult = await engine.flush();
+    expect(flushResult).toBe(true); // empty queue returns true
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    await jest.runAllTimersAsync();
+  });
+
+  it('should fall back to fetch when sendBeacon returns false', async () => {
+    mockSendBeacon.mockReturnValue(false);
+    const engine = createEngine();
+    const uploadSpy = jest.spyOn(engine, 'upload');
+    engine.send({ value: 1 }, 'my_event');
+
+    jest.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(mockSendBeacon).toHaveBeenCalledTimes(1);
+    // Events should still be in the queue and flushed via fetch
     expect(uploadSpy).toHaveBeenCalledTimes(1);
     expect(uploadSpy).toHaveBeenCalledWith(expect.any(Object), { keepalive: true });
 
     await jest.runAllTimersAsync();
   });
 
+  it('should fall back to fetch when sendBeacon is unavailable', async () => {
+    mockSendBeacon.mockRestore();
+    const original = navigator.sendBeacon;
+    Object.defineProperty(navigator, 'sendBeacon', { value: undefined, configurable: true });
+
+    try {
+      const engine = createEngine();
+      const uploadSpy = jest.spyOn(engine, 'upload');
+      engine.send({ value: 1 }, 'my_event');
+
+      jest.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+      document.dispatchEvent(new Event('visibilitychange'));
+
+      expect(uploadSpy).toHaveBeenCalledTimes(1);
+      expect(uploadSpy).toHaveBeenCalledWith(expect.any(Object), { keepalive: true });
+    } finally {
+      Object.defineProperty(navigator, 'sendBeacon', { value: original, configurable: true });
+    }
+
+    await jest.runAllTimersAsync();
+  });
+
   it('should not use keepalive for regular flushes', async () => {
-    const engine = new EventSenderEngine({
-      clientSecret: 'my_secret',
-      maxBatchSize: BATCH_SIZE,
-      flushTimeoutMilliseconds: FLUSH_TIMEOUT,
-      fetchImplementation: mockFetch as any,
-      region: 'eu',
-      maxOpenRequests: MAX_OPEN_REQUESTS,
-      logger: {},
-    });
+    const engine = createEngine();
     const uploadSpy = jest.spyOn(engine, 'upload');
     engine.send({ value: 1 }, 'my_event');
 
@@ -57,6 +129,40 @@ describe('EventSenderEngine visibilitychange', () => {
 
     expect(uploadSpy).toHaveBeenCalledTimes(1);
     expect(uploadSpy).toHaveBeenCalledWith(expect.any(Object), { keepalive: undefined });
+    expect(mockSendBeacon).not.toHaveBeenCalled();
+
+    await jest.runAllTimersAsync();
+  });
+
+  it('should not beacon when queue is empty', async () => {
+    createEngine();
+
+    jest.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(mockSendBeacon).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    await jest.runAllTimersAsync();
+  });
+
+  it('should include sendTime in beaconed payload', async () => {
+    const engine = createEngine();
+    engine.send({ value: 1 }, 'my_event');
+
+    jest.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    const blob: Blob = mockSendBeacon.mock.calls[0][1];
+    const body = JSON.parse(
+      await new Promise<string>(resolve => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.readAsText(blob);
+      }),
+    );
+    expect(body.sendTime).toBeDefined();
+    expect(new Date(body.sendTime).getTime()).not.toBeNaN();
 
     await jest.runAllTimersAsync();
   });

--- a/packages/sdk/src/EventSenderEngine.visibilitychange.test.ts
+++ b/packages/sdk/src/EventSenderEngine.visibilitychange.test.ts
@@ -166,4 +166,31 @@ describe('EventSenderEngine visibilitychange', () => {
 
     await jest.runAllTimersAsync();
   });
+
+  it('should cap beacon batch size and leave remaining events in queue', async () => {
+    const engine = createEngine({ maxBatchSize: 100 });
+    // Send 40 events — more than the 25-event beacon cap but within maxBatchSize
+    for (let i = 0; i < 40; i++) {
+      engine.send({ value: i }, 'my_event');
+    }
+
+    engine.clearPendingFlush();
+
+    jest.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(mockSendBeacon).toHaveBeenCalledTimes(1);
+    const blob: Blob = mockSendBeacon.mock.calls[0][1];
+    const body = JSON.parse(
+      await new Promise<string>(resolve => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.readAsText(blob);
+      }),
+    );
+    // Only 25 events beaconed, 15 remain in queue
+    expect(body.events).toHaveLength(25);
+
+    await jest.runAllTimersAsync();
+  });
 });


### PR DESCRIPTION
## Summary

The `visibilitychange` handler in `EventSenderEngine` uses `fetch({keepalive: true})` to flush queued events when the page becomes hidden. This is unreliable for page-unload delivery because:

- The 64KB keepalive budget is shared across all in-flight keepalive requests (including SDK telemetry)
- `fetch({keepalive})` has weaker browser guarantees than `navigator.sendBeacon()` for tab-close/navigate-away scenarios

We observed a ~95% drop in event samples (from 35-55k/day to ~2.5k/day) after switching from a transport that used `sendBeacon` to the Confidence SDK.

### Changes

Adds a `beaconFlush()` private method to `EventSenderEngine` that:
- Serializes the queue synchronously and calls `navigator.sendBeacon()` directly, bypassing the async `FetchBuilder` chain
- Caps the beacon batch at 25 events to stay within sendBeacon's ~64KB payload limit
- Falls back to `fetch({keepalive: true})` when `sendBeacon` is unavailable or the browser rejects the beacon
- No changes to the `upload()` public API

### Known limitation

`beaconFlush()` bypasses the configured `fetchImplementation` by design. sendBeacon must serialize and enqueue synchronously during page unload — the async FetchBuilder middleware chain cannot guarantee completion before the page is discarded. Consumers relying on `fetchImplementation` for proxying or instrumentation should be aware that visibilitychange flushes take a different path.

### Note

Session recordings (`csr`) use the same `keepalive` approach in their flush — this fix only addresses `EventSenderEngine` but the same pattern could be applied there.

#### :heavy_check_mark: Checklist

- [x] All tests are passing
- [ ] Relevant documentation updated
- [x] linter/style run on changed files
- [x] Tests added for new functionality
- [x] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app