### PR TITLE
feat(csr): expose userTriggeredOnInput option

### DIFF
--- a/csr/csr-recorder/src/engine/rrweb-engine.ts
+++ b/csr/csr-recorder/src/engine/rrweb-engine.ts
@@ -34,6 +34,7 @@ export class RrwebEngine implements RecordingEngine {
         ...(maskSelectors.length ? { maskTextSelector: maskSelectors.join(',') } : {}),
         ...(blockSelectors.length ? { blockSelector: blockSelectors.join(',') } : {}),
         ...(plugins.length ? { plugins } : {}),
+        ...(config.userTriggeredOnInput ? { userTriggeredOnInput: true } : {}),
         sampling: {
           mousemove: 100,
           input: 'last',

--- a/csr/csr-recorder/src/types.ts
+++ b/csr/csr-recorder/src/types.ts
@@ -71,6 +71,11 @@ export interface RecordingConfig {
    * Import `defaultParameterizeRoute` to compose with the built-in rules.
    */
   parameterizeRoute?: (route: string) => string;
+  /**
+   * Tag each input event with a `userTriggered` flag derived from the
+   * browser's `event.isTrusted` property. Defaults to `false`.
+   */
+  userTriggeredOnInput?: boolean;
 }
 
 export enum RecorderState {

--- a/csr/session-recording/src/index.ts
+++ b/csr/session-recording/src/index.ts
@@ -31,6 +31,12 @@ export interface InitSessionRecorderOptions {
   /** Capture client-side route changes (pathname only). Defaults to `true`. */
   captureRouteChanges?: boolean;
   /**
+   * Tag each input event with a `userTriggered` flag derived from the
+   * browser's `event.isTrusted` property. When enabled, the analyzer can
+   * filter out programmatic input changes. Defaults to `false`.
+   */
+  userTriggeredOnInput?: boolean;
+  /**
    * Transform a raw pathname into a route pattern before it is emitted in
    * route-change and Meta events. For example, `/users/123/profile` becomes
    * `/users/:id/profile`. This ensures per-page metrics are grouped by route
@@ -109,6 +115,7 @@ export function initSessionRecorder(options: InitSessionRecorderOptions): Sessio
     captureNetworkRequests: options.captureNetworkRequests,
     captureRouteChanges: options.captureRouteChanges,
     parameterizeRoute: options.parameterizeRoute,
+    userTriggeredOnInput: options.userTriggeredOnInput,
   };
 
   async function initAndRecord(forceRecord: boolean) {


### PR DESCRIPTION
## Summary
- Pass rrweb's `userTriggeredOnInput` through the recorder and session-recording SDK so each input event carries an `isTrusted` flag
- Downstream analyzers can use this to filter out programmatic input changes (e.g. a playback slider updating at 60fps that floods recordings with spurious input events)

## Changes
- `csr-recorder/src/types.ts` — add `userTriggeredOnInput?: boolean` to `RecordingConfig`
- `csr-recorder/src/engine/rrweb-engine.ts` — pass it through to rrweb's `record()`
- `session-recording/src/index.ts` — expose in `InitSessionRecorderOptions` and forward to recorder config
- `csr-common/src/events.ts` — add `fieldType` and `hasValue` to `InputCustomData` payload type