### PR TITLE
fix(build): normalize Windows path separators in rollup external check

### DIFF
--- a/rollup.base.mjs
+++ b/rollup.base.mjs
@@ -106,11 +106,12 @@ function createExternalTest(prefix, external = []) {
  *
  * @param id the imported path
  * @param parent absolute path of the file containing the import, or undefined if it's the entry point
- * @returns path relative to cwd
+ * @returns path relative to cwd, always with forward slashes
  */
 function normalizePath(id, parent = '') {
   const absolute = id.startsWith('.') ? resolve(parent, id) : id;
-  return relative(cwd, absolute);
+  // relative() yields backslashes on Windows, which would break the prefix checks in createExternalTest
+  return relative(cwd, absolute).replaceAll('\\', '/');
 }
 
 /**


### PR DESCRIPTION
Split out from #419, which is otherwise closed — this is the one change from it worth landing.

`normalizePath()` returns the result of `relative()` verbatim. On Windows that is backslash-separated, so the `path.startsWith(prefix)` checks in `createExternalTest` (where `prefix` is `build/`) never match, and local `build/` imports get misreported as unbundleable external dependencies:

```
Error: Attempt to bundle external dependency build\Confidence.js for import ./Confidence.js.
Are we missing a dependency?
```

Normalizing to forward slashes makes the prefix checks work on both platforms. No behavior change on POSIX, where `relative()` already returns forward slashes.

Credit to @vihaan-vijay, who found this while working on #419; retained as co-author on the commit.

## Verification

`yarn bundle` passes locally (macOS). The Windows path is not exercised by CI — this is a fix for local development on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)