### PR TITLE
fix(build): ship .d.cts so CJS TypeScript consumers can resolve types

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -23,6 +23,8 @@ jobs:
       - run: yarn lint
       - run: yarn format:check
       - run: yarn test
+      # packs and installs the tarballs, so it can only run against a completed bundle
+      - run: yarn verify:types
 
   Build-And-Test-CSR:
     runs-on: ubuntu-latest

--- a/emit-dcts.sh
+++ b/emit-dcts.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Emit a .d.cts alongside each bundled .d.ts.
+#
+# Our packages are "type": "module", so a .d.ts is read as ESM declarations. A TypeScript
+# consumer resolving the "require" condition under moduleResolution=node16 looks for a
+# .d.cts sibling; without one it falls back to the ESM .d.ts and reports TS1479 ("the
+# referenced file is an ECMAScript module and cannot be imported with 'require'").
+#
+# The content is identical to the .d.ts: rollup emits named exports in both the .mjs and
+# .cjs bundles, and `export { X }` inside a .d.cts describes exactly that CJS shape.
+#
+# This runs at the end of the bundle step so it copies whatever is actually shipped -- for
+# the sdk that is api-extractor's trimmed rollup, which overwrites rollup-plugin-dts' output.
+
+set -e
+
+for FILE in ./dist/*.d.ts; do
+  [ -e "$FILE" ] || continue
+  NAME=$(basename "$FILE" .d.ts)
+  echo "Emitting $NAME.d.cts"
+  cp "$FILE" "./dist/$NAME.d.cts"
+done

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "jest --testPathIgnorePatterns '\\.e2e\\.test\\.ts'",
     "test:csr": "vitest run --config vitest.csr.config.ts",
     "test:e2e": "jest --testPathPattern '\\.e2e\\.test\\.ts'",
+    "verify:types": "./verify-types.sh",
     "prepare": "husky install",
     "cm": "git-cz"
   },

--- a/packages/openfeature-server-provider/package.json
+++ b/packages/openfeature-server-provider/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "bundle": "rollup -c && ../../validate-api.sh",
+    "bundle": "rollup -c && ../../validate-api.sh && ../../emit-dcts.sh",
     "prepack": "yarn build && yarn bundle",
     "clean": "rm -rf {build,dist}"
   },
@@ -33,9 +33,14 @@
     "access": "public",
     "exports": {
       ".": {
-        "import": "./dist/index.mjs",
-        "require": "./dist/index.cjs",
-        "types": "./dist/index.d.ts"
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.mjs"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
       }
     },
     "main": "dist/index.cjs",

--- a/packages/openfeature-web-provider/package.json
+++ b/packages/openfeature-web-provider/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "bundle": "rollup -c && ../../validate-api.sh",
+    "bundle": "rollup -c && ../../validate-api.sh && ../../emit-dcts.sh",
     "prepack": "yarn build && yarn bundle",
     "clean": "rm -rf {build,dist}"
   },
@@ -36,9 +36,14 @@
     "access": "public",
     "exports": {
       ".": {
-        "import": "./dist/index.mjs",
-        "require": "./dist/index.cjs",
-        "types": "./dist/index.d.ts"
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.mjs"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
       }
     },
     "main": "dist/index.cjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -16,7 +16,7 @@
     "patch-next-dev": "patch-next-dev.cjs"
   },
   "scripts": {
-    "bundle": "rollup -c && ../../validate-api.sh",
+    "bundle": "rollup -c && ../../validate-api.sh && ../../emit-dcts.sh",
     "build": "tsc",
     "prepack": "yarn build && yarn bundle && cp dist/* .",
     "clean": "rm -rf {build,dist}",
@@ -59,14 +59,24 @@
     "types": "index.d.ts",
     "exports": {
       ".": {
-        "import": "./index.mjs",
-        "require": "./index.cjs",
-        "types": "./index.d.ts"
+        "import": {
+          "types": "./index.d.ts",
+          "default": "./index.mjs"
+        },
+        "require": {
+          "types": "./index.d.cts",
+          "default": "./index.cjs"
+        }
       },
       "./server": {
-        "import": "./server.mjs",
-        "require": "./server.cjs",
-        "types": "./server.d.ts"
+        "import": {
+          "types": "./server.d.ts",
+          "default": "./server.mjs"
+        },
+        "require": {
+          "types": "./server.d.cts",
+          "default": "./server.cjs"
+        }
       }
     }
   }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "gen:proto": "protoc --plugin=$(yarn bin protoc-gen-ts_proto) --ts_proto_out=src/generated -I proto proto/confidence/flags/resolver/v1/api.proto proto/confidence/telemetry/v1/telemetry.proto --ts_proto_opt=outputEncodeMethods=true --ts_proto_opt=outputPartialMethods=false && prettier --config ../../prettier.config.js -w src/generated",
     "build": "tsc",
-    "bundle": "rollup -c && api-extractor run",
+    "bundle": "rollup -c && api-extractor run && ../../emit-dcts.sh",
     "prepack": "yarn build && yarn bundle",
     "clean": "rm -rf {build,dist}"
   },
@@ -37,9 +37,14 @@
     "access": "public",
     "exports": {
       ".": {
-        "import": "./dist/index.mjs",
-        "require": "./dist/index.cjs",
-        "types": "./dist/index.d.ts"
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.mjs"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
       }
     },
     "main": "dist/index.cjs",

--- a/verify-types.sh
+++ b/verify-types.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+
+# Verify that both ESM and CJS TypeScript consumers can resolve types from the packed
+# tarballs under moduleResolution=node16.
+#
+# This is deliberately run against `npm pack` output rather than the workspace: the
+# top-level "exports" in each package.json point at build/ for local development, and it
+# is publishConfig -- merged in only at pack time -- that describes what consumers see.
+# The unit suite can't cover this either, since jest.resolver.js maps @spotify-confidence/*
+# straight to src/.
+#
+# The .cts entry is the regression guard for #422: with no .d.cts for the "require"
+# condition TypeScript either falls back to the ESM .d.ts and reports TS1479, or -- once
+# the condition names a .d.cts that isn't shipped -- finds no declarations at all (TS7016).
+
+set -e
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+PACKAGES="sdk openfeature-web-provider openfeature-server-provider react"
+
+# explicit template: BSD mktemp ignores TMPDIR
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/verify-types.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "Packing workspace packages..."
+for NAME in $PACKAGES; do
+  (cd "$ROOT/packages/$NAME" && yarn pack --out "$WORK/$NAME.tgz" >/dev/null)
+done
+
+cat > "$WORK/package.json" <<'EOF'
+{
+  "name": "verify-types",
+  "private": true,
+  "version": "0.0.0"
+}
+EOF
+
+echo "Installing into a scratch consumer project..."
+cd "$WORK"
+# hermetic cache: this must not depend on, or write to, the developer's shared npm cache
+npm install --no-audit --no-fund --cache "$WORK/.npm-cache" \
+  ./sdk.tgz ./openfeature-web-provider.tgz ./openfeature-server-provider.tgz ./react.tgz \
+  @openfeature/web-sdk@^1.0.3 @openfeature/server-sdk@^1.13.5 \
+  react@^19 @types/react@^19 @types/node@^22 typescript@5.1.6 >npm-install.log 2>&1 ||
+  { cat npm-install.log; exit 1; }
+
+# One .mts and one .cts per package. The importing file's extension decides which export
+# condition TypeScript resolves through, so this covers both branches of the exports map.
+for NAME in $PACKAGES; do
+  case "$NAME" in
+    sdk) SPECIFIER="@spotify-confidence/sdk" ;;
+    react) SPECIFIER="@spotify-confidence/react" ;;
+    *) SPECIFIER="@spotify-confidence/$NAME" ;;
+  esac
+  printf "import * as m from '%s';\nexport type T = typeof m;\n" "$SPECIFIER" > "$WORK/$NAME.mts"
+  printf "import * as m from '%s';\nexport type T = typeof m;\n" "$SPECIFIER" > "$WORK/$NAME.cts"
+done
+
+# react also publishes a ./server subpath
+printf "import * as m from '@spotify-confidence/react/server';\nexport type T = typeof m;\n" > "$WORK/react-server.mts"
+printf "import * as m from '@spotify-confidence/react/server';\nexport type T = typeof m;\n" > "$WORK/react-server.cts"
+
+cat > "$WORK/tsconfig.json" <<'EOF'
+{
+  "compilerOptions": {
+    "module": "node16",
+    "moduleResolution": "node16",
+    "jsx": "react",
+    "strict": true,
+    "noEmit": true,
+
+    // This test is about module resolution, not about type-checking our dependencies'
+    // declarations (@bufbuild/protobuf, for one, needs a newer TS than we pin). Nothing
+    // we care about is hidden: TS1479 and TS2307 are reported against the importing
+    // .cts/.mts file, which is never skipped.
+    "skipLibCheck": true
+  },
+  "include": ["*.mts", "*.cts"]
+}
+EOF
+
+echo "Type-checking ESM (.mts) and CJS (.cts) entries under moduleResolution=node16..."
+./node_modules/.bin/tsc -p tsconfig.json
+
+echo "OK: all packages resolve types from both the import and require conditions."

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -65,18 +65,13 @@ module.exports = defineConfig({
           main: 'index.cjs',
           module: 'index.mjs',
           types: 'index.d.ts',
-          exports: {
-            '.': {
-              import: './index.mjs',
-              require: './index.cjs',
-              types: './index.d.ts',
+          exports: conditionalExports(
+            {
+              '.': 'index',
+              './server': 'server',
             },
-            './server': {
-              import: './server.mjs',
-              require: './server.cjs',
-              types: './server.d.ts',
-            },
-          },
+            './',
+          ),
         });
       } else {
         workspace.set('files', ['dist/index.*']);
@@ -93,9 +88,9 @@ module.exports = defineConfig({
       }
 
       if (workspace.cwd === 'packages/sdk') {
-        workspace.set('scripts.bundle', 'rollup -c && api-extractor run');
+        workspace.set('scripts.bundle', 'rollup -c && api-extractor run && ../../emit-dcts.sh');
       } else {
-        workspace.set('scripts.bundle', 'rollup -c && ../../validate-api.sh');
+        workspace.set('scripts.bundle', 'rollup -c && ../../validate-api.sh && ../../emit-dcts.sh');
       }
 
       workspace.set('scripts.build', 'tsc');
@@ -134,17 +129,28 @@ function buildExports(map) {
     }),
   );
 }
-function distExports(map) {
+/**
+ * Build a conditional exports map for bundled output living under `prefix`.
+ *
+ * `types` is nested inside each condition rather than listed as a sibling: conditions are
+ * matched in order, so a top-level `types` after `import`/`require` is never reached. The
+ * require branch points at .d.cts (see emit-dcts.sh) so that CJS consumers on
+ * moduleResolution=node16 don't fall back to the ESM .d.ts.
+ */
+function conditionalExports(map, prefix) {
   return Object.fromEntries(
     Object.entries(map).map(([key, value]) => {
       if (typeof value === 'string') {
         value = {
-          import: `./dist/${value}.mjs`,
-          require: `./dist/${value}.cjs`,
-          types: `./dist/${value}.d.ts`,
+          import: { types: `${prefix}${value}.d.ts`, default: `${prefix}${value}.mjs` },
+          require: { types: `${prefix}${value}.d.cts`, default: `${prefix}${value}.cjs` },
         };
       }
       return [key, value];
     }),
   );
+}
+
+function distExports(map) {
+  return conditionalExports(map, './dist/');
 }


### PR DESCRIPTION
Fixes #422.

## Problem

`require()` already worked at runtime, but TypeScript consumers on `moduleResolution: node16` still failed:

```
error TS1479: The current file is a CommonJS module whose imports will produce 'require' calls;
however, the referenced file is an ECMAScript module and cannot be imported with 'require'.
```

Our packages are `"type": "module"`, so `dist/index.d.ts` is read as **ESM** declarations. The `require` condition resolves to `dist/index.cjs`, TypeScript looks for a sibling `dist/index.d.cts`, doesn't find one, and falls back to the ESM `.d.ts`.

## Changes

**`emit-dcts.sh`** — copies each bundled `.d.ts` to `.d.cts` at the end of the `bundle` step.

This runs after the whole step rather than as a second `rollup-plugin-dts` output, which matters for the sdk: its `bundle` is `rollup -c && api-extractor run`, and api-extractor *overwrites* `dist/index.d.ts` via `publicTrimmedFilePath`. A rollup-emitted `.d.cts` would silently ship the untrimmed rollup while `.d.ts` shipped the trimmed one. Verified the shipped `.d.cts` carries api-extractor's trimming markers and is byte-identical to the `.d.ts` for all four packages.

The content being identical is correct: rollup emits named exports in both bundles, and `export { X }` in a `.d.cts` describes exactly that CJS shape.

**`publishConfig.exports`** — `types` moves inside each condition:

```json
"exports": {
  ".": {
    "import":  { "types": "./dist/index.d.ts",  "default": "./dist/index.mjs" },
    "require": { "types": "./dist/index.d.cts", "default": "./dist/index.cjs" }
  }
}
```

As a sibling listed *after* `import`/`require` it was never reached — conditions match in order. The react branch of `yarn.config.cjs` now shares the same helper instead of duplicating the literal.

The top-level `exports` (pointing at `build/`) are unchanged: they are the monorepo's own dev resolution, not what consumers see. Legacy `main`/`module`/`types` stay in `publishConfig`.

**`verify-types.sh`** (`yarn verify:types`) — packs the tarballs, installs them into a scratch project, and type-checks one `.mts` and one `.cts` entry per package (plus `@spotify-confidence/react/server`) under `moduleResolution: node16`. The importing file's extension is what selects the export condition, so this exercises both branches.

This can't live in the unit suite: `jest.resolver.js` maps `@spotify-confidence/*` straight to `src/`, and the top-level `exports` don't describe the published package. Wired into `Build.yml` after `yarn bundle`.

## Verification

- `yarn bundle` emits `.d.cts` for all four packages (react gets both `index` and `server`).
- `yarn verify:types` passes.
- **Negative control:** deleting a shipped `.d.cts` makes the check fail (TS7016), so the guard is not vacuous.
- `yarn lint`, `yarn format:check`, `yarn constraints` clean; 175 tests pass.

## Note for reviewers

`skipLibCheck` is `true` in the verification tsconfig. It has to be — `@bufbuild/protobuf` needs a newer TS than the 5.1.6 we pin, and its declarations error out otherwise. Nothing relevant is masked: TS1479/TS7016 are reported against the importing `.cts`/`.mts` file, which is never skipped, and the negative control confirms it.

**React's fix is only complete with a co-upgraded sdk.** Its `.d.cts` imports `@spotify-confidence/sdk` under the `require` condition, so a consumer on an older sdk within the `>=0.3.1 <0.4.0` peer range has no `.d.cts` to resolve against. That degrades to today's behaviour rather than anything worse.

Committed as `fix` rather than `build` deliberately: release-please only treats `feat`/`fix`/breaking as releasable units, and `build` would land this without ever publishing it. Expect four patch releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)