### PR TITLE
feat(csr-recorder): capture GraphQL operation names

### DIFF
--- a/csr/csr-common/src/events.ts
+++ b/csr/csr-common/src/events.ts
@@ -230,6 +230,10 @@ export type ConsoleLogPluginData = {
 
 export type NetworkRequestInitiator = 'fetch' | 'xhr';
 
+export type GraphQLRequestMetadata = {
+  operationName: string;
+};
+
 /**
  * Plugin event data emitted by the recorder for network requests.
  */
@@ -243,6 +247,7 @@ export type NetworkRequestPluginData = {
     durationMs: number;
     requestSize?: number;
     responseSize?: number;
+    graphql?: GraphQLRequestMetadata;
   };
 };
 

--- a/csr/csr-common/src/index.ts
+++ b/csr/csr-common/src/index.ts
@@ -23,6 +23,7 @@ export {
   type ConsoleLogLevel,
   type ConsoleLogPluginData,
   type NetworkRequestInitiator,
+  type GraphQLRequestMetadata,
   type NetworkRequestPluginData,
   type RouteChangeTrigger,
   type RouteChangePayload,

--- a/csr/csr-recorder/src/graphql-request.test.ts
+++ b/csr/csr-recorder/src/graphql-request.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { extractGraphQLRequestMetadata } from './graphql-request';
+
+describe('extractGraphQLRequestMetadata', () => {
+  it('uses the explicit operation name', () => {
+    const body = JSON.stringify({
+      operationName: 'UpdateProfile',
+      query: 'mutation UpdateProfile($input: ProfileInput!) { updateProfile(input: $input) { id } }',
+      variables: { input: { displayName: 'Private value' } },
+    });
+
+    expect(extractGraphQLRequestMetadata('/graphql', body)).toEqual({ operationName: 'UpdateProfile' });
+  });
+
+  it('gets the operation name from the document when it is not explicit', () => {
+    const body = JSON.stringify({ query: 'query Viewer { viewer { id email } }' });
+
+    expect(extractGraphQLRequestMetadata('/graphql', body)).toEqual({ operationName: 'Viewer' });
+  });
+
+  it('does not record anonymous query fields', () => {
+    expect(extractGraphQLRequestMetadata('/graphql', '{ viewer { id email } }')).toBeUndefined();
+  });
+
+  it('ignores requests to other paths', () => {
+    expect(extractGraphQLRequestMetadata('/api/query', 'query Viewer { viewer { id } }')).toBeUndefined();
+  });
+});

--- a/csr/csr-recorder/src/graphql-request.ts
+++ b/csr/csr-recorder/src/graphql-request.ts
@@ -1,0 +1,32 @@
+import type { GraphQLRequestMetadata } from '@spotify-confidence/csr-common';
+
+function operationNameFromDocument(document: string): string | undefined {
+  const match = document.match(/\b(?:query|mutation|subscription)\s+([_A-Za-z][_0-9A-Za-z]*)/);
+  return match?.[1];
+}
+
+function operationNameFromBody(body: unknown): string | undefined {
+  if (typeof body !== 'string') return undefined;
+  try {
+    const request = JSON.parse(body) as { operationName?: unknown; query?: unknown };
+    if (typeof request.operationName === 'string' && request.operationName) return request.operationName;
+    return typeof request.query === 'string' ? operationNameFromDocument(request.query) : undefined;
+  } catch (_error) {
+    return operationNameFromDocument(body);
+  }
+}
+
+function isGraphQLRequestUrl(url: string): boolean {
+  try {
+    return new URL(url, globalThis.location?.href).pathname.endsWith('/graphql');
+  } catch (_error) {
+    return url.split(/[?#]/, 1)[0].endsWith('/graphql');
+  }
+}
+
+export function extractGraphQLRequestMetadata(url: string, body: unknown): GraphQLRequestMetadata | undefined {
+  if (!isGraphQLRequestUrl(url)) return undefined;
+
+  const operationName = operationNameFromBody(body);
+  return operationName ? { operationName } : undefined;
+}

--- a/csr/csr-recorder/src/recorder.test.ts
+++ b/csr/csr-recorder/src/recorder.test.ts
@@ -204,4 +204,32 @@ describe('Recorder network request capture', () => {
 
     recorder.stop();
   });
+
+  it('captures only the GraphQL operation name', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response('{}', { status: 500 }));
+
+    const engine = new MockEngine();
+    const onEvent = vi.fn();
+    const recorder = new Recorder({ engine, onEvent });
+    recorder.start({ captureNetworkRequests: true });
+
+    await globalThis.fetch('https://api.example.com/graphql', {
+      method: 'POST',
+      body: JSON.stringify({
+        operationName: 'GetUser',
+        query: `query GetUser($id: ID!) {
+          viewer { id }
+          selectedUser: user(id: $id) { ...UserDetails }
+        }
+        fragment UserDetails on User { name email }`,
+        variables: { id: 'private-user-id' },
+      }),
+    });
+
+    const data = onEvent.mock.calls[0][0].data as NetworkRequestPluginData;
+    expect(data.payload.graphql).toEqual({ operationName: 'GetUser' });
+    expect(JSON.stringify(data.payload)).not.toContain('private-user-id');
+
+    recorder.stop();
+  });
 });

--- a/csr/csr-recorder/src/recorder.ts
+++ b/csr/csr-recorder/src/recorder.ts
@@ -9,6 +9,7 @@ import {
 import { RecorderOptions, RecorderState, RecordingConfig } from './types';
 import { RecordingEngine } from './engine';
 import { defaultParameterizeRoute } from './route-parameterizer';
+import { extractGraphQLRequestMetadata } from './graphql-request';
 
 export class Recorder {
   private readonly engine: RecordingEngine;
@@ -107,6 +108,7 @@ export class Recorder {
         url = String(input);
       }
       const requestSize = init?.body ? new Blob([init.body as BlobPart]).size : undefined;
+      const graphql = extractGraphQLRequestMetadata(url, init?.body);
       const start = Date.now();
 
       return originalFetch.call(globalThis, input, init).then(
@@ -120,6 +122,7 @@ export class Recorder {
             durationMs: Date.now() - start,
             ...(requestSize !== null && requestSize !== undefined ? { requestSize } : {}),
             ...(contentLength ? { responseSize: Number(contentLength) } : {}),
+            ...(graphql ? { graphql } : {}),
           });
           return response;
         },
@@ -131,6 +134,7 @@ export class Recorder {
             status: 0,
             durationMs: Date.now() - start,
             ...(requestSize !== null && requestSize !== undefined ? { requestSize } : {}),
+            ...(graphql ? { graphql } : {}),
           });
           throw error;
         },
@@ -165,6 +169,7 @@ export class Recorder {
       const method = (meta.__csr_method as string) ?? 'GET';
       const url = (meta.__csr_url as string) ?? '';
       const requestSize = body !== null && body !== undefined ? new Blob([body as BlobPart]).size : undefined;
+      const graphql = extractGraphQLRequestMetadata(url, body);
       const start = Date.now();
 
       this.addEventListener('loadend', function csrLoadend(this: XMLHttpRequest) {
@@ -177,6 +182,7 @@ export class Recorder {
           durationMs: Date.now() - start,
           ...(requestSize !== null && requestSize !== undefined ? { requestSize } : {}),
           ...(contentLength ? { responseSize: Number(contentLength) } : {}),
+          ...(graphql ? { graphql } : {}),
         });
       });
 


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

Reports GraphQL query/mutation names (not fields, headers or responses), as part of session recording diagnostic events. 

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing
- [ ] Relevant documentation updated
- [x] linter/style run on changed files
- [x] Tests added for new functionality
- [x] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app
