### PR TITLE
feat(csr-recorder): capture click modifier keys

### DIFF
--- a/csr/csr-common/src/events.ts
+++ b/csr/csr-common/src/events.ts
@@ -72,6 +72,12 @@ export type MouseInteractionData = {
   x?: number;
   y?: number;
   pointerType?: number;
+  /** Mouse button and modifier keys present on click events. */
+  button?: number;
+  altKey?: boolean;
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+  shiftKey?: boolean;
 };
 
 export type SelectionRange = {
@@ -148,6 +154,11 @@ export type ClickCustomData = {
     targetId: number;
     element?: ElementDescriptor;
     pathname?: string;
+    button?: number;
+    altKey?: boolean;
+    ctrlKey?: boolean;
+    metaKey?: boolean;
+    shiftKey?: boolean;
   };
 };
 

--- a/csr/csr-recorder/src/engine/rrweb-engine.test.ts
+++ b/csr/csr-recorder/src/engine/rrweb-engine.test.ts
@@ -1,9 +1,12 @@
+// @vitest-environment happy-dom
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { RrwebEngine } from './rrweb-engine';
 
 const recordSpy = vi.fn().mockReturnValue(() => {});
 
-vi.mock('rrweb', () => ({
+vi.mock('rrweb', async importOriginal => ({
+  ...(await importOriginal<typeof import('rrweb')>()),
   record: (opts: unknown) => recordSpy(opts),
 }));
 
@@ -59,5 +62,67 @@ describe('RrwebEngine', () => {
   it('enables slimDOMOptions to strip head noise', () => {
     new RrwebEngine().start({}, () => {});
     expect(recordSpy.mock.calls[0][0].slimDOMOptions).toBe('all');
+  });
+
+  it('adds native click modifier keys to the rrweb click event', () => {
+    new RrwebEngine().start({}, () => {});
+    const plugin = recordSpy.mock.calls[0][0].plugins.find(
+      ({ name }: { name: string }) => name === 'csr/click-modifiers@1',
+    );
+    const removeObserver = plugin.observer(() => {}, window);
+
+    document.dispatchEvent(
+      new MouseEvent('click', {
+        button: 0,
+        altKey: true,
+        ctrlKey: true,
+        metaKey: true,
+        shiftKey: true,
+      }),
+    );
+
+    expect(
+      plugin.eventProcessor({
+        type: 3,
+        timestamp: 1,
+        data: { source: 2, type: 2, id: 7, x: 10, y: 20 },
+      }),
+    ).toEqual({
+      type: 3,
+      timestamp: 1,
+      data: {
+        source: 2,
+        type: 2,
+        id: 7,
+        x: 10,
+        y: 20,
+        button: 0,
+        altKey: true,
+        ctrlKey: true,
+        metaKey: true,
+        shiftKey: true,
+      },
+    });
+
+    removeObserver();
+  });
+
+  it('does not add stale modifiers to a later click', async () => {
+    new RrwebEngine().start({}, () => {});
+    const plugin = recordSpy.mock.calls[0][0].plugins.find(
+      ({ name }: { name: string }) => name === 'csr/click-modifiers@1',
+    );
+    const removeObserver = plugin.observer(() => {}, window);
+    document.dispatchEvent(new MouseEvent('click', { metaKey: true }));
+    await Promise.resolve();
+
+    const event = {
+      type: 3,
+      timestamp: 1,
+      data: { source: 2, type: 2, id: 7 },
+    };
+    expect(plugin.eventProcessor(event)).toBe(event);
+
+    removeObserver();
   });
 });

--- a/csr/csr-recorder/src/engine/rrweb-engine.ts
+++ b/csr/csr-recorder/src/engine/rrweb-engine.ts
@@ -1,10 +1,62 @@
-import { RecordingEvent, type ConsoleLogLevel } from '@spotify-confidence/csr-common';
+import { type ConsoleLogLevel, type RecordingEvent } from '@spotify-confidence/csr-common';
 import { RecordingConfig, DEFAULT_MASK_SELECTORS, DEFAULT_BLOCK_SELECTORS } from '../types';
 import { RecordingEngine } from './index';
-import { record } from 'rrweb';
+import { EventType, IncrementalSource, MouseInteractions, record, type recordOptions } from 'rrweb';
 import { getRecordConsolePlugin } from '@rrweb/rrweb-plugin-console-record';
 
 const ALL_CONSOLE_LEVELS: ConsoleLogLevel[] = ['log', 'warn', 'error', 'debug', 'info'];
+
+type RrwebPlugin = NonNullable<recordOptions<RecordingEvent>['plugins']>[number];
+
+type ClickModifiers = Pick<MouseEvent, 'button' | 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>;
+
+/**
+ * rrweb does not include modifier keys in mouse-interaction events. Capture
+ * the native click first, then add its safe, non-text metadata to the rrweb
+ * event emitted during the same browser event dispatch.
+ */
+function clickModifiersPlugin(): RrwebPlugin {
+  let pendingClick: ClickModifiers | null = null;
+
+  return {
+    name: 'csr/click-modifiers@1',
+    options: {},
+    observer: (_callback, win) => {
+      const onClick = (event: Event) => {
+        const click = event as MouseEvent;
+        pendingClick = {
+          button: click.button,
+          altKey: click.altKey,
+          ctrlKey: click.ctrlKey,
+          metaKey: click.metaKey,
+          shiftKey: click.shiftKey,
+        };
+        queueMicrotask(() => {
+          pendingClick = null;
+        });
+      };
+
+      win.addEventListener('click', onClick, true);
+      return () => win.removeEventListener('click', onClick, true);
+    },
+    eventProcessor: event => {
+      if (
+        pendingClick &&
+        event.type === EventType.IncrementalSnapshot &&
+        event.data.source === IncrementalSource.MouseInteraction &&
+        event.data.type === MouseInteractions.Click
+      ) {
+        const click = pendingClick;
+        pendingClick = null;
+        return {
+          ...event,
+          data: { ...event.data, ...click },
+        };
+      }
+      return event;
+    },
+  };
+}
 
 /**
  * rrweb adapter — bundles rrweb so consumers don't take a peer-dep on it.
@@ -16,7 +68,7 @@ export class RrwebEngine implements RecordingEngine {
     const maskSelectors = config.maskSelectors ?? DEFAULT_MASK_SELECTORS;
     const blockSelectors = config.blockSelectors ?? DEFAULT_BLOCK_SELECTORS;
 
-    const plugins = [];
+    const plugins: RrwebPlugin[] = [clickModifiersPlugin()];
     const { captureConsoleLogs } = config;
     if (captureConsoleLogs) {
       const levels = captureConsoleLogs === true ? ALL_CONSOLE_LEVELS : captureConsoleLogs.levels;


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

- Captures modifier keys when recording click events

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing
- [ ] Relevant documentation updated
- [x] linter/style run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app
