### PR TITLE
feat: support tracking in OpenFeature providers

### DIFF
--- a/api/openfeature-server-provider.d.ts
+++ b/api/openfeature-server-provider.d.ts
@@ -1,4 +1,4 @@
-import { Provider, ProviderMetadata, ProviderStatus, EvaluationContext, ResolutionDetails, JsonValue } from '@openfeature/server-sdk';
+import { Provider, ProviderMetadata, ProviderStatus, EvaluationContext, ResolutionDetails, JsonValue, EvaluationContextValue } from '@openfeature/server-sdk';
 import { FlagResolver, Confidence } from '@spotify-confidence/sdk';
 
 /**
@@ -22,6 +22,10 @@ declare class ConfidenceServerProvider implements Provider {
     resolveObjectEvaluation<T extends JsonValue>(flagKey: string, defaultValue: T, context: EvaluationContext): Promise<ResolutionDetails<T>>;
     /** Resolves with an evaluation of a String flag */
     resolveStringEvaluation(flagKey: string, defaultValue: string, context: EvaluationContext): Promise<ResolutionDetails<string>>;
+    /** Tracks an event */
+    track(trackingEventName: string, context?: EvaluationContext, trackingEventDetails?: {
+        [key: string]: EvaluationContextValue;
+    }): void;
     onClose(): Promise<void>;
 }
 

--- a/api/openfeature-server-provider.d.ts
+++ b/api/openfeature-server-provider.d.ts
@@ -25,6 +25,8 @@ declare class ConfidenceServerProvider implements Provider {
     /** Tracks an event */
     track(trackingEventName: string, context?: EvaluationContext, trackingEventDetails?: {
         [key: string]: EvaluationContextValue;
+    } & {
+        context?: never;
     }): void;
     onClose(): Promise<void>;
 }

--- a/api/openfeature-web-provider.d.ts
+++ b/api/openfeature-web-provider.d.ts
@@ -1,4 +1,4 @@
-import { Provider, ProviderMetadata, OpenFeatureEventEmitter, EvaluationContext, ResolutionDetails, JsonValue } from '@openfeature/web-sdk';
+import { Provider, ProviderMetadata, OpenFeatureEventEmitter, EvaluationContext, ResolutionDetails, JsonValue, EvaluationContextValue } from '@openfeature/web-sdk';
 import { FlagResolver, Confidence } from '@spotify-confidence/sdk';
 
 /**
@@ -30,6 +30,10 @@ declare class ConfidenceWebProvider implements Provider {
     resolveObjectEvaluation<T extends JsonValue>(flagKey: string, defaultValue: T): ResolutionDetails<T>;
     /** Resolves with an evaluation of a String flag */
     resolveStringEvaluation(flagKey: string, defaultValue: string): ResolutionDetails<string>;
+    /** Tracks an event */
+    track(trackingEventName: string, context?: EvaluationContext, trackingEventDetails?: {
+        [key: string]: EvaluationContextValue;
+    }): void;
 }
 
 /**

--- a/api/openfeature-web-provider.d.ts
+++ b/api/openfeature-web-provider.d.ts
@@ -33,6 +33,8 @@ declare class ConfidenceWebProvider implements Provider {
     /** Tracks an event */
     track(trackingEventName: string, context?: EvaluationContext, trackingEventDetails?: {
         [key: string]: EvaluationContextValue;
+    } & {
+        context?: never;
     }): void;
 }
 

--- a/packages/openfeature-server-provider/README.md
+++ b/packages/openfeature-server-provider/README.md
@@ -55,7 +55,7 @@ client.track(
 );
 ```
 
-Tracking details are added to the Confidence event payload. `context` is reserved for the evaluation context and must not be used as a tracking detail key.
+Tracking details are added to the Confidence event payload. `context` is reserved for the evaluation context and is ignored when used as a tracking detail key.
 
 ## Region
 

--- a/packages/openfeature-server-provider/README.md
+++ b/packages/openfeature-server-provider/README.md
@@ -40,6 +40,23 @@ client
   });
 ```
 
+## Tracking
+
+With `@openfeature/server-sdk` 1.16.0 or later, events can be tracked with a request-specific evaluation context:
+
+```ts
+client.track(
+  'checkout',
+  { targetingKey: 'your targeting key' },
+  {
+    value: 42,
+    currency: 'SEK',
+  },
+);
+```
+
+Tracking details are added to the Confidence event payload. `context` is reserved for the evaluation context and must not be used as a tracking detail key.
+
 ## Region
 
 The region option is used to set the region for the network request to the Confidence backend. When the region is not set, the default (global) region will be used.

--- a/packages/openfeature-server-provider/package.json
+++ b/packages/openfeature-server-provider/package.json
@@ -8,8 +8,8 @@
     "directory": "packages/openfeature-server-provider"
   },
   "devDependencies": {
-    "@openfeature/core": "^1.1.0",
-    "@openfeature/server-sdk": "^1.13.5",
+    "@openfeature/core": "^1.5.0",
+    "@openfeature/server-sdk": "^1.16.0",
     "@spotify-confidence/sdk": "workspace:*",
     "rollup": "4.24.0",
     "typescript": "5.1.6"

--- a/packages/openfeature-server-provider/src/ConfidenceServerProvider.test.ts
+++ b/packages/openfeature-server-provider/src/ConfidenceServerProvider.test.ts
@@ -1,4 +1,4 @@
-import { ProviderStatus } from '@openfeature/web-sdk';
+import { OpenFeature, ProviderStatus } from '@openfeature/server-sdk';
 import { Confidence } from '@spotify-confidence/sdk';
 import { ConfidenceServerProvider } from './ConfidenceServerProvider';
 
@@ -63,5 +63,31 @@ describe('ConfidenceServerProvider', () => {
       currency: 'SEK',
       purchasedAt: '2026-02-03T04:05:06.000Z',
     });
+  });
+
+  it('should track through the OpenFeature client with merged context', async () => {
+    try {
+      OpenFeature.setContext({ targetingKey: 'global', plan: 'premium' });
+      await OpenFeature.setProviderAndWait(instanceUnderTest);
+
+      OpenFeature.getClient().track(
+        'checkout',
+        { targetingKey: 'user-a', requestId: 'request-a' },
+        { value: 42, currency: 'SEK' },
+      );
+
+      expect(withContextMock).toHaveBeenLastCalledWith({
+        targeting_key: 'user-a',
+        plan: 'premium',
+        requestId: 'request-a',
+      });
+      expect(trackMock).toHaveBeenCalledWith('checkout', {
+        value: 42,
+        currency: 'SEK',
+      });
+    } finally {
+      await OpenFeature.clearProviders();
+      OpenFeature.setContext({});
+    }
   });
 });

--- a/packages/openfeature-server-provider/src/ConfidenceServerProvider.test.ts
+++ b/packages/openfeature-server-provider/src/ConfidenceServerProvider.test.ts
@@ -6,9 +6,11 @@ const withContextMock = jest.fn(function withContext() {
   return this;
 });
 const evaluateFlagMock = jest.fn();
+const trackMock = jest.fn();
 const mockConfidence = {
   withContext: withContextMock,
   evaluateFlag: evaluateFlagMock,
+  track: trackMock,
 } as unknown as Confidence;
 
 const evaluation = {
@@ -43,5 +45,23 @@ describe('ConfidenceServerProvider', () => {
     expect(withContextMock).toHaveBeenNthCalledWith(2, { another_context: 5 });
 
     expect(evaluateFlagMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should track with converted context and event details', () => {
+    instanceUnderTest.track(
+      'checkout',
+      { targetingKey: 'user-a', registeredAt: new Date('2026-01-02T03:04:05Z') },
+      { value: 42, currency: 'SEK', purchasedAt: new Date('2026-02-03T04:05:06Z') },
+    );
+
+    expect(withContextMock).toHaveBeenCalledWith({
+      targeting_key: 'user-a',
+      registeredAt: '2026-01-02T03:04:05.000Z',
+    });
+    expect(trackMock).toHaveBeenCalledWith('checkout', {
+      value: 42,
+      currency: 'SEK',
+      purchasedAt: '2026-02-03T04:05:06.000Z',
+    });
   });
 });

--- a/packages/openfeature-server-provider/src/ConfidenceServerProvider.test.ts
+++ b/packages/openfeature-server-provider/src/ConfidenceServerProvider.test.ts
@@ -65,6 +65,21 @@ describe('ConfidenceServerProvider', () => {
     });
   });
 
+  it('should ignore a reserved context event detail', () => {
+    instanceUnderTest.track(
+      'checkout',
+      { targetingKey: 'user-a' },
+      {
+        value: 42,
+        // @ts-expect-error context is reserved for the evaluation context
+        context: { source: 'event-details' },
+      },
+    );
+
+    expect(withContextMock).toHaveBeenCalledWith({ targeting_key: 'user-a' });
+    expect(trackMock).toHaveBeenCalledWith('checkout', { value: 42 });
+  });
+
   it('should track through the OpenFeature client with merged context', async () => {
     try {
       OpenFeature.setContext({ targetingKey: 'global', plan: 'premium' });

--- a/packages/openfeature-server-provider/src/ConfidenceServerProvider.ts
+++ b/packages/openfeature-server-provider/src/ConfidenceServerProvider.ts
@@ -7,8 +7,6 @@ import {
   ProviderMetadata,
   ProviderStatus,
   ResolutionDetails,
-  TrackingEventDetails,
-  TrackingEventValue,
 } from '@openfeature/server-sdk';
 
 import { Context, EventData, EventSender, FlagEvaluation, FlagResolver, Value } from '@spotify-confidence/sdk';
@@ -100,7 +98,7 @@ export class ConfidenceServerProvider implements Provider {
   track(
     trackingEventName: string,
     context: EvaluationContext = {},
-    trackingEventDetails: TrackingEventDetails = {},
+    trackingEventDetails: { [key: string]: EvaluationContextValue } = {},
   ): void {
     const scopedConfidence = this.confidence.withContext(convertContext(context));
     // The public constructor still accepts custom FlagResolvers created before tracking support was added.
@@ -124,7 +122,7 @@ function convertContext({ targetingKey, ...context }: EvaluationContext): Contex
   return { ...targetingContext, ...convertStruct(context) };
 }
 
-function convertValue(value: EvaluationContextValue | TrackingEventValue): Value {
+function convertValue(value: EvaluationContextValue): Value {
   if (typeof value === 'object') {
     if (value === null) return undefined;
     if (value instanceof Date) return value.toISOString();
@@ -135,7 +133,7 @@ function convertValue(value: EvaluationContextValue | TrackingEventValue): Value
   return value;
 }
 
-function convertStruct(value: { [key: string]: EvaluationContextValue | TrackingEventValue }): Value.Struct {
+function convertStruct(value: { [key: string]: EvaluationContextValue }): Value.Struct {
   const struct: Mutable<Value.Struct> = {};
   for (const key of Object.keys(value)) {
     if (typeof value[key] === 'undefined') continue;

--- a/packages/openfeature-server-provider/src/ConfidenceServerProvider.ts
+++ b/packages/openfeature-server-provider/src/ConfidenceServerProvider.ts
@@ -104,7 +104,7 @@ export class ConfidenceServerProvider implements Provider {
     // The public constructor still accepts custom FlagResolvers created before tracking support was added.
     if (!isEventSender(scopedConfidence)) {
       throw new TypeError(
-        'The configured FlagResolver does not support event tracking; construct the provider with a Confidence instance',
+        'The configured FlagResolver does not support event tracking; construct the provider with a full Confidence instance',
       );
     }
     // Dynamic event details can bypass the public type; do not let them replace the evaluation context.

--- a/packages/openfeature-server-provider/src/ConfidenceServerProvider.ts
+++ b/packages/openfeature-server-provider/src/ConfidenceServerProvider.ts
@@ -98,14 +98,17 @@ export class ConfidenceServerProvider implements Provider {
   track(
     trackingEventName: string,
     context: EvaluationContext = {},
-    trackingEventDetails: { [key: string]: EvaluationContextValue } = {},
+    trackingEventDetails: { [key: string]: EvaluationContextValue } & { context?: never } = {},
   ): void {
     const scopedConfidence = this.confidence.withContext(convertContext(context));
     // The public constructor still accepts custom FlagResolvers created before tracking support was added.
     if (!isEventSender(scopedConfidence)) {
-      throw new TypeError('Confidence instance does not support event tracking');
+      throw new TypeError(
+        'The configured FlagResolver does not support event tracking; construct the provider with a Confidence instance',
+      );
     }
-    scopedConfidence.track(trackingEventName, convertStruct(trackingEventDetails) as EventData);
+    // Dynamic event details can bypass the public type; do not let them replace the evaluation context.
+    scopedConfidence.track(trackingEventName, convertStruct(trackingEventDetails, 'context') as EventData);
   }
 
   async onClose(): Promise<void> {
@@ -133,10 +136,10 @@ function convertValue(value: EvaluationContextValue): Value {
   return value;
 }
 
-function convertStruct(value: { [key: string]: EvaluationContextValue }): Value.Struct {
+function convertStruct(value: { [key: string]: EvaluationContextValue }, ignoredKey?: string): Value.Struct {
   const struct: Mutable<Value.Struct> = {};
   for (const key of Object.keys(value)) {
-    if (typeof value[key] === 'undefined') continue;
+    if (key === ignoredKey || typeof value[key] === 'undefined') continue;
     struct[key] = convertValue(value[key]);
   }
   return struct;

--- a/packages/openfeature-server-provider/src/ConfidenceServerProvider.ts
+++ b/packages/openfeature-server-provider/src/ConfidenceServerProvider.ts
@@ -7,9 +7,11 @@ import {
   ProviderMetadata,
   ProviderStatus,
   ResolutionDetails,
+  TrackingEventDetails,
+  TrackingEventValue,
 } from '@openfeature/server-sdk';
 
-import { Context, FlagEvaluation, FlagResolver, Value } from '@spotify-confidence/sdk';
+import { Context, EventData, EventSender, FlagEvaluation, FlagResolver, Value } from '@spotify-confidence/sdk';
 
 type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 
@@ -94,9 +96,27 @@ export class ConfidenceServerProvider implements Provider {
     return this.fetchFlag(flagKey, defaultValue, context);
   }
 
+  /** Tracks an event */
+  track(
+    trackingEventName: string,
+    context: EvaluationContext = {},
+    trackingEventDetails: TrackingEventDetails = {},
+  ): void {
+    const scopedConfidence = this.confidence.withContext(convertContext(context));
+    // The public constructor still accepts custom FlagResolvers created before tracking support was added.
+    if (!isEventSender(scopedConfidence)) {
+      throw new TypeError('Confidence instance does not support event tracking');
+    }
+    scopedConfidence.track(trackingEventName, convertStruct(trackingEventDetails) as EventData);
+  }
+
   async onClose(): Promise<void> {
     this.confidence.close?.();
   }
+}
+
+function isEventSender(confidence: FlagResolver): confidence is FlagResolver & EventSender {
+  return 'track' in confidence && typeof confidence.track === 'function';
 }
 
 function convertContext({ targetingKey, ...context }: EvaluationContext): Context {
@@ -104,7 +124,7 @@ function convertContext({ targetingKey, ...context }: EvaluationContext): Contex
   return { ...targetingContext, ...convertStruct(context) };
 }
 
-function convertValue(value: EvaluationContextValue): Value {
+function convertValue(value: EvaluationContextValue | TrackingEventValue): Value {
   if (typeof value === 'object') {
     if (value === null) return undefined;
     if (value instanceof Date) return value.toISOString();
@@ -115,7 +135,7 @@ function convertValue(value: EvaluationContextValue): Value {
   return value;
 }
 
-function convertStruct(value: { [key: string]: EvaluationContextValue }): Value.Struct {
+function convertStruct(value: { [key: string]: EvaluationContextValue | TrackingEventValue }): Value.Struct {
   const struct: Mutable<Value.Struct> = {};
   for (const key of Object.keys(value)) {
     if (typeof value[key] === 'undefined') continue;

--- a/packages/openfeature-web-provider/README.md
+++ b/packages/openfeature-web-provider/README.md
@@ -62,7 +62,7 @@ client.track('checkout', {
 });
 ```
 
-Tracking details are added to the Confidence event payload. `context` is reserved for the evaluation context and must not be used as a tracking detail key.
+Tracking details are added to the Confidence event payload. `context` is reserved for the evaluation context and is ignored when used as a tracking detail key.
 
 ## Region
 

--- a/packages/openfeature-web-provider/README.md
+++ b/packages/openfeature-web-provider/README.md
@@ -51,6 +51,19 @@ Notes:
 
 - In the above example we first set the context and then set the provider and await for the provider to become ready before getting the flag value. Other ways of arranging these calls might make more sense depending on what app framework you are using. See the example apps for more inspiration.
 
+## Tracking
+
+With `@openfeature/web-sdk` 1.3.0 or later, events can be tracked using the context set on OpenFeature:
+
+```ts
+client.track('checkout', {
+  value: 42,
+  currency: 'SEK',
+});
+```
+
+Tracking details are added to the Confidence event payload. `context` is reserved for the evaluation context and must not be used as a tracking detail key.
+
 ## Region
 
 The region option is used to set the region for the network request to the Confidence backend. When the region is not set, the default (global) region will be used.

--- a/packages/openfeature-web-provider/package.json
+++ b/packages/openfeature-web-provider/package.json
@@ -11,8 +11,8 @@
     "fast-deep-equal": "^3.1.3"
   },
   "devDependencies": {
-    "@openfeature/core": "^1.1.0",
-    "@openfeature/web-sdk": "^1.0.3",
+    "@openfeature/core": "^1.5.0",
+    "@openfeature/web-sdk": "^1.3.0",
     "@spotify-confidence/sdk": "workspace:*",
     "rollup": "4.24.0",
     "typescript": "5.1.6"

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.test.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.test.ts
@@ -1,4 +1,4 @@
-import { EvaluationContext, ProviderEvents } from '@openfeature/web-sdk';
+import { EvaluationContext, OpenFeature, ProviderEvents } from '@openfeature/web-sdk';
 import { ConfidenceWebProvider } from './ConfidenceWebProvider';
 import { EventSender, FlagResolver, StateObserver } from '@spotify-confidence/sdk';
 
@@ -49,6 +49,27 @@ describe('ConfidenceProvider', () => {
       });
       // Tracking with a scoped context must not subscribe to flag state or trigger reconciliation.
       expect(confidenceMock.subscribe).not.toHaveBeenCalled();
+    });
+
+    it('tracks through the OpenFeature client with global context', async () => {
+      try {
+        await OpenFeature.setContext({ targetingKey: 'user-a', plan: 'premium' });
+        await OpenFeature.setProviderAndWait(instanceUnderTest);
+
+        OpenFeature.getClient().track('checkout', { value: 42, currency: 'SEK' });
+
+        expect(confidenceMock.withContext).toHaveBeenLastCalledWith({
+          targeting_key: 'user-a',
+          plan: 'premium',
+        });
+        expect(confidenceMock.track).toHaveBeenCalledWith('checkout', {
+          value: 42,
+          currency: 'SEK',
+        });
+      } finally {
+        await OpenFeature.clearProviders();
+        await OpenFeature.setContext({});
+      }
     });
   });
 

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.test.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.test.ts
@@ -1,8 +1,8 @@
 import { EvaluationContext, ProviderEvents } from '@openfeature/web-sdk';
 import { ConfidenceWebProvider } from './ConfidenceWebProvider';
-import { FlagResolver, StateObserver } from '@spotify-confidence/sdk';
+import { EventSender, FlagResolver, StateObserver } from '@spotify-confidence/sdk';
 
-const confidenceMock: jest.Mocked<FlagResolver> = {
+const confidenceMock: jest.Mocked<FlagResolver> & jest.Mocked<Pick<EventSender, 'track'>> = {
   getContext: jest.fn(),
   setContext: jest.fn(),
   withContext: jest.fn(),
@@ -10,6 +10,7 @@ const confidenceMock: jest.Mocked<FlagResolver> = {
   subscribe: jest.fn(),
   evaluateFlag: jest.fn(),
   getFlag: jest.fn(),
+  track: jest.fn(),
 };
 
 const dummyContext: EvaluationContext = { targetingKey: 'test' };
@@ -20,11 +21,34 @@ describe('ConfidenceProvider', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     instanceUnderTest = new ConfidenceWebProvider(confidenceMock);
+    confidenceMock.withContext.mockReturnValue(confidenceMock);
 
     // subscribe will by default immediately emit READY
     confidenceMock.subscribe.mockImplementation(observer => {
       observer!('READY');
       return jest.fn();
+    });
+  });
+
+  describe('track', () => {
+    it('tracks with converted context and event details', () => {
+      instanceUnderTest.track(
+        'checkout',
+        { targetingKey: 'user-a', registeredAt: new Date('2026-01-02T03:04:05Z') },
+        { value: 42, currency: 'SEK', purchasedAt: new Date('2026-02-03T04:05:06Z') },
+      );
+
+      expect(confidenceMock.withContext).toHaveBeenCalledWith({
+        targeting_key: 'user-a',
+        registeredAt: '2026-01-02T03:04:05.000Z',
+      });
+      expect(confidenceMock.track).toHaveBeenCalledWith('checkout', {
+        value: 42,
+        currency: 'SEK',
+        purchasedAt: '2026-02-03T04:05:06.000Z',
+      });
+      // Tracking with a scoped context must not subscribe to flag state or trigger reconciliation.
+      expect(confidenceMock.subscribe).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.test.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.test.ts
@@ -51,6 +51,21 @@ describe('ConfidenceProvider', () => {
       expect(confidenceMock.subscribe).not.toHaveBeenCalled();
     });
 
+    it('ignores a reserved context event detail', () => {
+      instanceUnderTest.track(
+        'checkout',
+        { targetingKey: 'user-a' },
+        {
+          value: 42,
+          // @ts-expect-error context is reserved for the evaluation context
+          context: { source: 'event-details' },
+        },
+      );
+
+      expect(confidenceMock.withContext).toHaveBeenCalledWith({ targeting_key: 'user-a' });
+      expect(confidenceMock.track).toHaveBeenCalledWith('checkout', { value: 42 });
+    });
+
     it('tracks through the OpenFeature client with global context', async () => {
       try {
         await OpenFeature.setContext({ targetingKey: 'user-a', plan: 'premium' });

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
@@ -8,8 +8,6 @@ import {
   ProviderEvents,
   ProviderMetadata,
   ResolutionDetails,
-  TrackingEventDetails,
-  TrackingEventValue,
 } from '@openfeature/web-sdk';
 import equal from 'fast-deep-equal';
 
@@ -139,7 +137,7 @@ export class ConfidenceWebProvider implements Provider {
   track(
     trackingEventName: string,
     context: EvaluationContext = {},
-    trackingEventDetails: TrackingEventDetails = {},
+    trackingEventDetails: { [key: string]: EvaluationContextValue } = {},
   ): void {
     const scopedConfidence = this.confidence.withContext(convertContext(context));
     // The public constructor still accepts custom FlagResolvers created before tracking support was added.
@@ -175,7 +173,7 @@ function convertContext({ targetingKey, ...context }: EvaluationContext): Contex
   return { ...targetingContext, ...convertStruct(context) };
 }
 
-function convertValue(value: EvaluationContextValue | TrackingEventValue): Value {
+function convertValue(value: EvaluationContextValue): Value {
   if (typeof value === 'object') {
     if (value === null) return undefined;
     if (value instanceof Date) return value.toISOString();
@@ -186,7 +184,7 @@ function convertValue(value: EvaluationContextValue | TrackingEventValue): Value
   return value;
 }
 
-function convertStruct(value: { [key: string]: EvaluationContextValue | TrackingEventValue }): Value.Struct {
+function convertStruct(value: { [key: string]: EvaluationContextValue }): Value.Struct {
   const struct: Mutable<Value.Struct> = {};
   for (const key of Object.keys(value)) {
     if (typeof value[key] === 'undefined') continue;

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
@@ -137,14 +137,17 @@ export class ConfidenceWebProvider implements Provider {
   track(
     trackingEventName: string,
     context: EvaluationContext = {},
-    trackingEventDetails: { [key: string]: EvaluationContextValue } = {},
+    trackingEventDetails: { [key: string]: EvaluationContextValue } & { context?: never } = {},
   ): void {
     const scopedConfidence = this.confidence.withContext(convertContext(context));
     // The public constructor still accepts custom FlagResolvers created before tracking support was added.
     if (!isEventSender(scopedConfidence)) {
-      throw new TypeError('Confidence instance does not support event tracking');
+      throw new TypeError(
+        'The configured FlagResolver does not support event tracking; construct the provider with a Confidence instance',
+      );
     }
-    scopedConfidence.track(trackingEventName, convertStruct(trackingEventDetails) as EventData);
+    // Dynamic event details can bypass the public type; do not let them replace the evaluation context.
+    scopedConfidence.track(trackingEventName, convertStruct(trackingEventDetails, 'context') as EventData);
   }
 }
 
@@ -184,10 +187,10 @@ function convertValue(value: EvaluationContextValue): Value {
   return value;
 }
 
-function convertStruct(value: { [key: string]: EvaluationContextValue }): Value.Struct {
+function convertStruct(value: { [key: string]: EvaluationContextValue }, ignoredKey?: string): Value.Struct {
   const struct: Mutable<Value.Struct> = {};
   for (const key of Object.keys(value)) {
-    if (typeof value[key] === 'undefined') continue;
+    if (key === ignoredKey || typeof value[key] === 'undefined') continue;
     struct[key] = convertValue(value[key]);
   }
   return struct;

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
@@ -8,10 +8,12 @@ import {
   ProviderEvents,
   ProviderMetadata,
   ResolutionDetails,
+  TrackingEventDetails,
+  TrackingEventValue,
 } from '@openfeature/web-sdk';
 import equal from 'fast-deep-equal';
 
-import { Value, Context, FlagResolver, FlagEvaluation } from '@spotify-confidence/sdk';
+import { Value, Context, EventData, EventSender, FlagResolver, FlagEvaluation } from '@spotify-confidence/sdk';
 
 type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 
@@ -132,6 +134,24 @@ export class ConfidenceWebProvider implements Provider {
   resolveStringEvaluation(flagKey: string, defaultValue: string): ResolutionDetails<string> {
     return this.evaluateFlag(flagKey, defaultValue);
   }
+
+  /** Tracks an event */
+  track(
+    trackingEventName: string,
+    context: EvaluationContext = {},
+    trackingEventDetails: TrackingEventDetails = {},
+  ): void {
+    const scopedConfidence = this.confidence.withContext(convertContext(context));
+    // The public constructor still accepts custom FlagResolvers created before tracking support was added.
+    if (!isEventSender(scopedConfidence)) {
+      throw new TypeError('Confidence instance does not support event tracking');
+    }
+    scopedConfidence.track(trackingEventName, convertStruct(trackingEventDetails) as EventData);
+  }
+}
+
+function isEventSender(confidence: FlagResolver): confidence is FlagResolver & EventSender {
+  return 'track' in confidence && typeof confidence.track === 'function';
 }
 
 function contextChanges(oldContext: EvaluationContext, newContext: EvaluationContext): EvaluationContext {
@@ -155,7 +175,7 @@ function convertContext({ targetingKey, ...context }: EvaluationContext): Contex
   return { ...targetingContext, ...convertStruct(context) };
 }
 
-function convertValue(value: EvaluationContextValue): Value {
+function convertValue(value: EvaluationContextValue | TrackingEventValue): Value {
   if (typeof value === 'object') {
     if (value === null) return undefined;
     if (value instanceof Date) return value.toISOString();
@@ -166,7 +186,7 @@ function convertValue(value: EvaluationContextValue): Value {
   return value;
 }
 
-function convertStruct(value: { [key: string]: EvaluationContextValue }): Value.Struct {
+function convertStruct(value: { [key: string]: EvaluationContextValue | TrackingEventValue }): Value.Struct {
   const struct: Mutable<Value.Struct> = {};
   for (const key of Object.keys(value)) {
     if (typeof value[key] === 'undefined') continue;

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
@@ -143,7 +143,7 @@ export class ConfidenceWebProvider implements Provider {
     // The public constructor still accepts custom FlagResolvers created before tracking support was added.
     if (!isEventSender(scopedConfidence)) {
       throw new TypeError(
-        'The configured FlagResolver does not support event tracking; construct the provider with a Confidence instance',
+        'The configured FlagResolver does not support event tracking; construct the provider with a full Confidence instance',
       );
     }
     // Dynamic event details can bypass the public type; do not let them replace the evaluation context.

--- a/packages/sdk/src/Confidence.test.ts
+++ b/packages/sdk/src/Confidence.test.ts
@@ -10,7 +10,9 @@ const flagResolverClientMock: jest.Mocked<FlagResolverClient> = {
   resolve: jest.fn(),
 };
 
-const eventSenderEngineMock: jest.Mocked<EventSenderEngine> = {} as any; // TODO fix any by using an interface
+const eventSenderEngineMock: jest.Mocked<EventSenderEngine> = {
+  send: jest.fn(),
+} as any; // TODO fix any by using an interface
 
 describe('Confidence', () => {
   let confidence: Confidence;
@@ -136,6 +138,16 @@ describe('Confidence', () => {
   });
 
   describe('track', () => {
+    it('tracks with child context without resolving flags', () => {
+      confidence.setContext({ targeting_key: 'parent' });
+      flagResolverClientMock.resolve.mockClear();
+
+      confidence.withContext({ targeting_key: 'child' }).track('checkout', { value: 42 });
+
+      expect(eventSenderEngineMock.send).toHaveBeenCalledWith({ targeting_key: 'child' }, 'checkout', { value: 42 });
+      expect(flagResolverClientMock.resolve).not.toHaveBeenCalled();
+    });
+
     it('sets up a subscription that can be closed once', () => {
       const mockManager = jest.fn();
       const mockCloser = jest.fn();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4027,28 +4027,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openfeature/core@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@openfeature/core@npm:1.1.0"
-  checksum: 10c0/fbb248ad415ae72efebf135c827164bf9ca703b12f26753b3a009bbc87674b9aceed59566b47161ae0a27dac3d8aad28108562877bd6534384ef53e12d002859
+"@openfeature/core@npm:^1.1.0, @openfeature/core@npm:^1.5.0":
+  version: 1.12.0
+  resolution: "@openfeature/core@npm:1.12.0"
+  checksum: 10c0/561aa31810b6bad7c787a61dfeef11615b3151773f751548b0d3bc894cf50d863ef45832f9b92f390bc7da7ba1c41be12ce6226a78c36a504dfd5e7fb97120bd
   languageName: node
   linkType: hard
 
-"@openfeature/server-sdk@npm:^1.13.5":
-  version: 1.13.5
-  resolution: "@openfeature/server-sdk@npm:1.13.5"
+"@openfeature/server-sdk@npm:^1.13.5, @openfeature/server-sdk@npm:^1.16.0":
+  version: 1.23.0
+  resolution: "@openfeature/server-sdk@npm:1.23.0"
   peerDependencies:
-    "@openfeature/core": 1.1.0
-  checksum: 10c0/1d9f3ebf86c10c70693f563aab184c9bb9fd8e0673e19d89c8cac78ee6ad4ef5070b1285835137e7aa5f261a5d1386665a19f9dffc486381e8cc35f5968fb3f4
+    "@openfeature/core": ^1.12.0
+  checksum: 10c0/2e9a5b57dece1d08a37a80f9a4118f1b22978693b865b4d8f9f89a97272aa9b125c5f94aa908670e3d83411252a43f2a9379c6b81d94f9361e8739740c1226e0
   languageName: node
   linkType: hard
 
-"@openfeature/web-sdk@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "@openfeature/web-sdk@npm:1.0.3"
+"@openfeature/web-sdk@npm:^1.3.0":
+  version: 1.10.0
+  resolution: "@openfeature/web-sdk@npm:1.10.0"
   peerDependencies:
-    "@openfeature/core": 1.1.0
-  checksum: 10c0/7917a2a73ffbf53adaa8d7ca3bd2a32ae49b9cc4d41007f698781d4aa70fc825ec82e8eed69746dcfdfb93f9b55ec2018d4b8c8922f19379c578bcdfc3744cba
+    "@openfeature/core": ^1.12.0
+  checksum: 10c0/70b2e470296a628d9e9ba4cff6d558487fff322e95bd68629606c7ba5be138194018865ccf33997488b39020e1466836072a22bd71e6a19f606bd4b07a867bfe
   languageName: node
   linkType: hard
 
@@ -5050,8 +5050,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@spotify-confidence/openfeature-server-provider@workspace:packages/openfeature-server-provider"
   dependencies:
-    "@openfeature/core": "npm:^1.1.0"
-    "@openfeature/server-sdk": "npm:^1.13.5"
+    "@openfeature/core": "npm:^1.5.0"
+    "@openfeature/server-sdk": "npm:^1.16.0"
     "@spotify-confidence/sdk": "workspace:*"
     rollup: "npm:4.24.0"
     typescript: "npm:5.1.6"
@@ -5065,8 +5065,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@spotify-confidence/openfeature-web-provider@workspace:packages/openfeature-web-provider"
   dependencies:
-    "@openfeature/core": "npm:^1.1.0"
-    "@openfeature/web-sdk": "npm:^1.0.3"
+    "@openfeature/core": "npm:^1.5.0"
+    "@openfeature/web-sdk": "npm:^1.3.0"
     "@spotify-confidence/sdk": "workspace:*"
     fast-deep-equal: "npm:^3.1.3"
     rollup: "npm:4.24.0"


### PR DESCRIPTION
## Summary

- forward OpenFeature tracking through the web and server Confidence providers
- preserve request/global context without triggering flag reconciliation
- retain compatibility with older supported OpenFeature peers
- add client-level coverage and usage documentation

## Testing

- yarn build
- yarn test
- yarn lint
- yarn format:check
- yarn bundle