### PR TITLE
fix: resnapshot pages restored from BFCache

### DIFF
--- a/csr/csr-recorder/src/engine/index.ts
+++ b/csr/csr-recorder/src/engine/index.ts
@@ -7,5 +7,6 @@ import { RecordingConfig } from '../types';
  */
 export interface RecordingEngine {
   start(config: RecordingConfig, onEvent: (event: RecordingEvent) => void): void;
+  takeFullSnapshot(): void;
   stop(): void;
 }

--- a/csr/csr-recorder/src/engine/rrweb-engine.test.ts
+++ b/csr/csr-recorder/src/engine/rrweb-engine.test.ts
@@ -4,14 +4,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { RrwebEngine } from './rrweb-engine';
 
 const recordSpy = vi.fn().mockReturnValue(() => {});
+const takeFullSnapshotSpy = vi.fn();
 
 vi.mock('rrweb', async importOriginal => ({
   ...(await importOriginal<typeof import('rrweb')>()),
   record: (opts: unknown) => recordSpy(opts),
+  takeFullSnapshot: (isCheckout: boolean) => takeFullSnapshotSpy(isCheckout),
 }));
 
 describe('RrwebEngine', () => {
-  beforeEach(() => recordSpy.mockClear());
+  beforeEach(() => {
+    recordSpy.mockClear();
+    takeFullSnapshotSpy.mockClear();
+  });
 
   it('defaults maskAllInputs=true when maskInputs is omitted', () => {
     new RrwebEngine().start({}, () => {});
@@ -124,5 +129,13 @@ describe('RrwebEngine', () => {
     expect(plugin.eventProcessor(event)).toBe(event);
 
     removeObserver();
+  });
+
+  it('takes a checkout snapshot when requested', () => {
+    const engine = new RrwebEngine();
+
+    engine.takeFullSnapshot();
+
+    expect(takeFullSnapshotSpy).toHaveBeenCalledWith(true);
   });
 });

--- a/csr/csr-recorder/src/engine/rrweb-engine.ts
+++ b/csr/csr-recorder/src/engine/rrweb-engine.ts
@@ -1,7 +1,7 @@
 import { type ConsoleLogLevel, type RecordingEvent } from '@spotify-confidence/csr-common';
 import { RecordingConfig, DEFAULT_MASK_SELECTORS, DEFAULT_BLOCK_SELECTORS } from '../types';
 import { RecordingEngine } from './index';
-import { EventType, IncrementalSource, MouseInteractions, record, type recordOptions } from 'rrweb';
+import { EventType, IncrementalSource, MouseInteractions, record, takeFullSnapshot, type recordOptions } from 'rrweb';
 import { getRecordConsolePlugin } from '@rrweb/rrweb-plugin-console-record';
 
 const ALL_CONSOLE_LEVELS: ConsoleLogLevel[] = ['log', 'warn', 'error', 'debug', 'info'];
@@ -93,6 +93,10 @@ export class RrwebEngine implements RecordingEngine {
         },
         slimDOMOptions: 'all',
       }) ?? null;
+  }
+
+  takeFullSnapshot(): void {
+    takeFullSnapshot(true);
   }
 
   stop(): void {

--- a/csr/csr-recorder/src/recorder-bfcache.test.ts
+++ b/csr/csr-recorder/src/recorder-bfcache.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest';
+import type { RecordingEvent } from '@spotify-confidence/csr-common';
+import type { RecordingEngine } from './engine';
+import { Recorder } from './recorder';
+
+class MockEngine implements RecordingEngine {
+  takeFullSnapshot = vi.fn();
+
+  start(_config: unknown, _onEvent: (event: RecordingEvent) => void): void {}
+
+  stop(): void {}
+}
+
+function dispatchPageShow(persisted: boolean): void {
+  const event = new Event('pageshow');
+  Object.defineProperty(event, 'persisted', { value: persisted });
+  window.dispatchEvent(event);
+}
+
+describe('Recorder BFCache restoration', () => {
+  it('takes a full snapshot when the page is restored from BFCache', () => {
+    const engine = new MockEngine();
+    const recorder = new Recorder({ engine, onEvent: vi.fn() });
+    recorder.start();
+
+    dispatchPageShow(true);
+
+    expect(engine.takeFullSnapshot).toHaveBeenCalledOnce();
+    recorder.stop();
+  });
+
+  it('does not take another snapshot for a normal pageshow event', () => {
+    const engine = new MockEngine();
+    const recorder = new Recorder({ engine, onEvent: vi.fn() });
+    recorder.start();
+
+    dispatchPageShow(false);
+
+    expect(engine.takeFullSnapshot).not.toHaveBeenCalled();
+    recorder.stop();
+  });
+
+  it('stops responding to pageshow events after recording stops', () => {
+    const engine = new MockEngine();
+    const recorder = new Recorder({ engine, onEvent: vi.fn() });
+    recorder.start();
+    recorder.stop();
+
+    dispatchPageShow(true);
+
+    expect(engine.takeFullSnapshot).not.toHaveBeenCalled();
+  });
+});

--- a/csr/csr-recorder/src/recorder-routing.test.ts
+++ b/csr/csr-recorder/src/recorder-routing.test.ts
@@ -24,6 +24,8 @@ class MockEngine implements RecordingEngine {
     this.onEvent = null;
   }
 
+  takeFullSnapshot(): void {}
+
   emit(event: RecordingEvent): void {
     this.onEvent?.(event);
   }

--- a/csr/csr-recorder/src/recorder.test.ts
+++ b/csr/csr-recorder/src/recorder.test.ts
@@ -23,6 +23,8 @@ class MockEngine implements RecordingEngine {
     this.onEvent = null;
   }
 
+  takeFullSnapshot(): void {}
+
   emit(event: RecordingEvent): void {
     this.onEvent?.(event);
   }

--- a/csr/csr-recorder/src/recorder.ts
+++ b/csr/csr-recorder/src/recorder.ts
@@ -16,6 +16,7 @@ export class Recorder {
   private readonly onEvent: (event: RecordingEvent) => void;
   private state: RecorderState = RecorderState.Idle;
   private visibilityHandler: (() => void) | null = null;
+  private pageShowHandler: ((event: PageTransitionEvent) => void) | null = null;
   private originalFetch: typeof globalThis.fetch | null = null;
   private originalXhrOpen: typeof XMLHttpRequest.prototype.open | null = null;
   private originalXhrSend: typeof XMLHttpRequest.prototype.send | null = null;
@@ -63,6 +64,15 @@ export class Recorder {
         });
       };
       document.addEventListener('visibilitychange', this.visibilityHandler);
+    }
+
+    if (typeof window !== 'undefined') {
+      this.pageShowHandler = event => {
+        if (event.persisted) {
+          this.engine.takeFullSnapshot();
+        }
+      };
+      window.addEventListener('pageshow', this.pageShowHandler);
     }
 
     if (config?.captureNetworkRequests) {
@@ -286,6 +296,10 @@ export class Recorder {
     if (this.visibilityHandler) {
       document.removeEventListener('visibilitychange', this.visibilityHandler);
       this.visibilityHandler = null;
+    }
+    if (this.pageShowHandler) {
+      window.removeEventListener('pageshow', this.pageShowHandler);
+      this.pageShowHandler = null;
     }
     this.restoreNetwork();
     this.restoreRouting();


### PR DESCRIPTION
## Summary

- emit a fresh rrweb checkout snapshot when a page is restored from BFCache
- prevent replay from remaining on the DOM of the page navigated away from
- clean up the pageshow listener when recording stops

## Verification

- 64 focused CSR recorder tests passed
- TypeScript check passed
- Prettier check passed