### PR TITLE
fix(csr-recorder): preserve native click modifiers

### DIFF
--- a/csr/csr-recorder/src/engine/rrweb-engine.test.ts
+++ b/csr/csr-recorder/src/engine/rrweb-engine.test.ts
@@ -64,7 +64,7 @@ describe('RrwebEngine', () => {
     expect(recordSpy.mock.calls[0][0].slimDOMOptions).toBe('all');
   });
 
-  it('adds native click modifier keys to the rrweb click event', () => {
+  it('keeps native click modifiers through a browser microtask checkpoint', async () => {
     new RrwebEngine().start({}, () => {});
     const plugin = recordSpy.mock.calls[0][0].plugins.find(
       ({ name }: { name: string }) => name === 'csr/click-modifiers@1',
@@ -80,6 +80,9 @@ describe('RrwebEngine', () => {
         shiftKey: true,
       }),
     );
+    // Browsers can run a microtask checkpoint between the window capture
+    // listener above and rrweb's document listener for a trusted click.
+    await Promise.resolve();
 
     expect(
       plugin.eventProcessor({
@@ -114,7 +117,7 @@ describe('RrwebEngine', () => {
     );
     const removeObserver = plugin.observer(() => {}, window);
     document.dispatchEvent(new MouseEvent('click', { metaKey: true }));
-    await Promise.resolve();
+    await new Promise(resolve => window.setTimeout(resolve, 0));
 
     const event = {
       type: 3,

--- a/csr/csr-recorder/src/engine/rrweb-engine.ts
+++ b/csr/csr-recorder/src/engine/rrweb-engine.ts
@@ -24,16 +24,17 @@ function clickModifiersPlugin(): RrwebPlugin {
     observer: (_callback, win) => {
       const onClick = (event: Event) => {
         const click = event as MouseEvent;
-        pendingClick = {
+        const modifiers = {
           button: click.button,
           altKey: click.altKey,
           ctrlKey: click.ctrlKey,
           metaKey: click.metaKey,
           shiftKey: click.shiftKey,
         };
-        queueMicrotask(() => {
-          pendingClick = null;
-        });
+        pendingClick = modifiers;
+        win.setTimeout(() => {
+          if (pendingClick === modifiers) pendingClick = null;
+        }, 0);
       };
 
       win.addEventListener('click', onClick, true);


### PR DESCRIPTION
## Summary

Native browsers can run a microtask checkpoint between the recorder plug-in’s window capture listener and rrweb’s document listener. The existing cleanup cleared the click modifier metadata during that checkpoint.

This change:

- Defers cleanup until the next task.
- Uses an identity check so an older timer cannot clear a newer click.
- Updates the regression test to include the browser microtask checkpoint.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing
- [ ] Relevant documentation updated
- [x] linter/style run on changed files
- [x] Tests added for new functionality
- [x] Regression tests added for bug fixes
- [x] Tested in a corresponding example app
