### PR TITLE
test(csr): await uploader fallback completion

### DIFF
--- a/csr/csr-common/src/uploader/create-uploader.test.ts
+++ b/csr/csr-common/src/uploader/create-uploader.test.ts
@@ -61,10 +61,6 @@ function installWorkerStubs(opts?: { workerThrows?: boolean; sharedWorkerThrows?
   }
 }
 
-function tick() {
-  return new Promise(r => setTimeout(r, 0));
-}
-
 describe('createUploader', () => {
   const blobUrls: string[] = [];
 
@@ -112,8 +108,14 @@ describe('createUploader', () => {
 
       const createUploader = await loadCreateUploader();
       const logs: string[] = [];
-      createUploader({ ...DEFAULTS, workerMode: 'dedicated', debugLogger: m => logs.push(m) });
-      await tick();
+      await expect(
+        createUploader({
+          ...DEFAULTS,
+          workerMode: 'dedicated',
+          debugLogger: m => logs.push(m),
+          _welcomeTimeoutMs: 0,
+        }),
+      ).rejects.toThrow(/welcome timeout/);
 
       expect(blobUrls).toHaveLength(0);
       expect(logs.some(l => l.includes('via data'))).toBe(true);
@@ -136,8 +138,14 @@ describe('createUploader', () => {
 
       const createUploader = await loadCreateUploader();
       const logs: string[] = [];
-      createUploader({ ...DEFAULTS, workerMode: 'dedicated', debugLogger: m => logs.push(m) });
-      await tick();
+      await expect(
+        createUploader({
+          ...DEFAULTS,
+          workerMode: 'dedicated',
+          debugLogger: m => logs.push(m),
+          _welcomeTimeoutMs: 0,
+        }),
+      ).rejects.toThrow(/welcome timeout/);
 
       expect(blobUrls).toHaveLength(1);
       expect(constructedUrl).toBe(blobUrls[0]);
@@ -163,8 +171,14 @@ describe('createUploader', () => {
 
       const createUploader = await loadCreateUploader();
       const logs: string[] = [];
-      createUploader({ ...DEFAULTS, workerMode: 'shared', debugLogger: m => logs.push(m) });
-      await tick();
+      await expect(
+        createUploader({
+          ...DEFAULTS,
+          workerMode: 'shared',
+          debugLogger: m => logs.push(m),
+          _welcomeTimeoutMs: 0,
+        }),
+      ).rejects.toThrow(/welcome timeout/);
 
       expect(blobUrls).toHaveLength(1);
       expect(constructedUrl).toBe(blobUrls[0]);


### PR DESCRIPTION
## Summary

- Wait for `createUploader()` to finish in the worker fallback tests.
- Remove async work that could continue after test cleanup.
- Prevent previous tests from changing the next test’s `blobUrls` state.

## Cause

Three tests started `createUploader()` but did not wait for it to finish. Pending worker and timeout operations could continue after `afterEach`, which caused the blob URL count to be either `0` or `2`.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing
- [ ] Relevant documentation updated
- [ ] linter/style run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app
