### PR TITLE
fix: stop passive recording frames extending sessions

### DIFF
--- a/csr/csr-common/src/events.ts
+++ b/csr/csr-common/src/events.ts
@@ -40,7 +40,9 @@ export const RecordingCustomEventTag = {
 } as const;
 
 export const RecordingPluginName = {
+  BlockedElementLabels: 'csr/blocked-element-labels@1',
   Clipboard: 'csr/clipboard@1',
+  ClickModifiers: 'csr/click-modifiers@1',
   TabVisibility: 'csr:tabVisibility',
   ConsoleLog: 'rrweb/console@1',
   NetworkRequest: 'csr:networkRequest',
@@ -330,6 +332,16 @@ export type FlagEvaluationPluginData = {
   };
 };
 
+export type PluginEventData =
+  | ClipboardPluginData
+  | TabVisibilityPluginData
+  | ConsoleLogPluginData
+  | NetworkRequestPluginData
+  | RouteChangePluginData
+  | TagPluginData
+  | MeasurePluginData
+  | FlagEvaluationPluginData;
+
 export type ErrorMessageCustomData = {
   tag: typeof RecordingCustomEventTag.ErrorMessage;
   payload: {
@@ -409,7 +421,15 @@ export type RecordingEvent =
       data: IncrementalSnapshotData;
     }
   | {
-      type: Exclude<RecordingEventType, RecordingEventType.Custom | RecordingEventType.IncrementalSnapshot>;
+      type: RecordingEventType.Plugin;
+      timestamp: number;
+      data: PluginEventData;
+    }
+  | {
+      type: Exclude<
+        RecordingEventType,
+        RecordingEventType.Custom | RecordingEventType.IncrementalSnapshot | RecordingEventType.Plugin
+      >;
       timestamp: number;
       data: unknown;
     };

--- a/csr/csr-common/src/events.ts
+++ b/csr/csr-common/src/events.ts
@@ -23,6 +23,33 @@ export enum RecordingEventType {
   Plugin = 6,
 }
 
+export const RecordingCustomEventTag = {
+  RageClick: 'csr:rageClick',
+  FormFieldReEdit: 'csr:formFieldReEdit',
+  ScrollBack: 'csr:scrollBack',
+  Click: 'csr:click',
+  Input: 'csr:input',
+  DeadClick: 'csr:deadClick',
+  TabUnfocus: 'csr:tabUnfocus',
+  TabRefocus: 'csr:tabRefocus',
+  RouteChange: 'csr:routeChange',
+  ErrorMessage: 'csr:errorMessage',
+  DialogOpened: 'csr:dialogOpened',
+  IdleGap: 'csr:idleGap',
+  AwayGap: 'csr:awayGap',
+} as const;
+
+export const RecordingPluginName = {
+  Clipboard: 'csr/clipboard@1',
+  TabVisibility: 'csr:tabVisibility',
+  ConsoleLog: 'rrweb/console@1',
+  NetworkRequest: 'csr:networkRequest',
+  RouteChange: 'csr:routeChange',
+  Tag: 'csr:tag',
+  Measure: 'csr:measure',
+  FlagEvaluation: 'csr:flagEvaluation',
+} as const;
+
 /**
  * Incremental snapshot sub-types.
  */
@@ -107,7 +134,7 @@ export type OpaqueIncrementalData = {
 export type IncrementalSnapshotData = MouseInteractionData | SelectionData | OpaqueIncrementalData;
 
 export type RageClickCustomData = {
-  tag: 'csr:rageClick';
+  tag: typeof RecordingCustomEventTag.RageClick;
   payload: {
     eventId?: string;
     targetId: number;
@@ -119,7 +146,7 @@ export type RageClickCustomData = {
 };
 
 export type FormFieldReEditCustomData = {
-  tag: 'csr:formFieldReEdit';
+  tag: typeof RecordingCustomEventTag.FormFieldReEdit;
   payload: {
     eventId?: string;
     targetId: number;
@@ -130,7 +157,7 @@ export type FormFieldReEditCustomData = {
 };
 
 export type ScrollBackCustomData = {
-  tag: 'csr:scrollBack';
+  tag: typeof RecordingCustomEventTag.ScrollBack;
   payload: {
     eventId?: string;
     scrollBackPx: number;
@@ -148,7 +175,7 @@ export type ElementDescriptor = {
 };
 
 export type ClickCustomData = {
-  tag: 'csr:click';
+  tag: typeof RecordingCustomEventTag.Click;
   payload: {
     eventId?: string;
     targetId: number;
@@ -163,7 +190,7 @@ export type ClickCustomData = {
 };
 
 export type InputCustomData = {
-  tag: 'csr:input';
+  tag: typeof RecordingCustomEventTag.Input;
   payload: {
     eventId?: string;
     targetId: number;
@@ -178,7 +205,7 @@ export type InputCustomData = {
 export type ClipboardAction = 'copy' | 'cut' | 'paste';
 
 export type ClipboardPluginData = {
-  plugin: 'csr/clipboard@1';
+  plugin: typeof RecordingPluginName.Clipboard;
   payload: {
     action: ClipboardAction;
     targetId: number;
@@ -186,7 +213,7 @@ export type ClipboardPluginData = {
 };
 
 export type DeadClickCustomData = {
-  tag: 'csr:deadClick';
+  tag: typeof RecordingCustomEventTag.DeadClick;
   payload: {
     eventId?: string;
     targetId: number;
@@ -196,7 +223,7 @@ export type DeadClickCustomData = {
 };
 
 export type TabUnfocusCustomData = {
-  tag: 'csr:tabUnfocus';
+  tag: typeof RecordingCustomEventTag.TabUnfocus;
   payload: {
     eventId?: string;
     pathname?: string;
@@ -204,7 +231,7 @@ export type TabUnfocusCustomData = {
 };
 
 export type TabRefocusCustomData = {
-  tag: 'csr:tabRefocus';
+  tag: typeof RecordingCustomEventTag.TabRefocus;
   payload: {
     eventId?: string;
     awayDurationMs: number;
@@ -221,7 +248,7 @@ export type RouteChangePayload = {
 };
 
 export type RouteChangeCustomData = {
-  tag: 'csr:routeChange';
+  tag: typeof RecordingCustomEventTag.RouteChange;
   // Intersected rather than added to RouteChangePayload so the plugin-event
   // shape (RouteChangePluginData) stays free of analyzer identity.
   payload: RouteChangePayload & { eventId?: string };
@@ -231,7 +258,7 @@ export type RouteChangeCustomData = {
  * Plugin event data emitted by the recorder for tab visibility changes.
  */
 export type TabVisibilityPluginData = {
-  plugin: 'csr:tabVisibility';
+  plugin: typeof RecordingPluginName.TabVisibility;
   payload: { hidden: boolean };
 };
 
@@ -242,7 +269,7 @@ export type ConsoleLogLevel = 'log' | 'warn' | 'error' | 'debug' | 'info';
  * Shape matches `@rrweb/rrweb-plugin-console-record` LogData.
  */
 export type ConsoleLogPluginData = {
-  plugin: 'rrweb/console@1';
+  plugin: typeof RecordingPluginName.ConsoleLog;
   payload: {
     level: ConsoleLogLevel;
     payload: string[];
@@ -260,7 +287,7 @@ export type GraphQLRequestMetadata = {
  * Plugin event data emitted by the recorder for network requests.
  */
 export type NetworkRequestPluginData = {
-  plugin: 'csr:networkRequest';
+  plugin: typeof RecordingPluginName.NetworkRequest;
   payload: {
     initiator: NetworkRequestInitiator;
     method: string;
@@ -274,12 +301,12 @@ export type NetworkRequestPluginData = {
 };
 
 export type RouteChangePluginData = {
-  plugin: 'csr:routeChange';
+  plugin: typeof RecordingPluginName.RouteChange;
   payload: RouteChangePayload;
 };
 
 export type TagPluginData = {
-  plugin: 'csr:tag';
+  plugin: typeof RecordingPluginName.Tag;
   payload: {
     key: string;
     value?: string;
@@ -287,7 +314,7 @@ export type TagPluginData = {
 };
 
 export type MeasurePluginData = {
-  plugin: 'csr:measure';
+  plugin: typeof RecordingPluginName.Measure;
   payload: {
     key: string;
     value?: number;
@@ -295,7 +322,7 @@ export type MeasurePluginData = {
 };
 
 export type FlagEvaluationPluginData = {
-  plugin: 'csr:flagEvaluation';
+  plugin: typeof RecordingPluginName.FlagEvaluation;
   payload: {
     flagKey: string;
     variant: string;
@@ -304,7 +331,7 @@ export type FlagEvaluationPluginData = {
 };
 
 export type ErrorMessageCustomData = {
-  tag: 'csr:errorMessage';
+  tag: typeof RecordingCustomEventTag.ErrorMessage;
   payload: {
     eventId?: string;
     text: string;
@@ -312,7 +339,7 @@ export type ErrorMessageCustomData = {
 };
 
 export type DialogOpenedCustomData = {
-  tag: 'csr:dialogOpened';
+  tag: typeof RecordingCustomEventTag.DialogOpened;
   payload: {
     eventId?: string;
     content: string[];
@@ -320,7 +347,7 @@ export type DialogOpenedCustomData = {
 };
 
 export type IdleGapCustomData = {
-  tag: 'csr:idleGap';
+  tag: typeof RecordingCustomEventTag.IdleGap;
   payload: {
     eventId?: string;
     visibleGapS: number;
@@ -331,7 +358,7 @@ export type IdleGapCustomData = {
 };
 
 export type AwayGapCustomData = {
-  tag: 'csr:awayGap';
+  tag: typeof RecordingCustomEventTag.AwayGap;
   payload: {
     eventId?: string;
     totalGapS: number;

--- a/csr/csr-common/src/index.ts
+++ b/csr/csr-common/src/index.ts
@@ -42,6 +42,8 @@ export {
 
 export { stripUrl } from './url';
 
+export { isSessionActivityEvent, isUserInteractionEvent } from './session-activity';
+
 export {
   MAX_KEY_LENGTH,
   MAX_TAG_VALUE_LENGTH,

--- a/csr/csr-common/src/index.ts
+++ b/csr/csr-common/src/index.ts
@@ -42,7 +42,7 @@ export {
 
 export { stripUrl } from './url';
 
-export { isSessionActivityEvent, isUserInteractionEvent } from './session-activity';
+export { isSessionActivityEvent, isUserInteractionEvent, isUserInteractionMetric } from './session-activity';
 
 export {
   MAX_KEY_LENGTH,

--- a/csr/csr-common/src/index.ts
+++ b/csr/csr-common/src/index.ts
@@ -1,6 +1,8 @@
 export {
   SerializedNodeType,
   RecordingEventType,
+  RecordingCustomEventTag,
+  RecordingPluginName,
   IncrementalSource,
   MouseInteractions,
   type RecordingEvent,
@@ -41,6 +43,8 @@ export {
 } from './events';
 
 export { stripUrl } from './url';
+
+export { RecordingMetricKey, type RecordingMetricKeyValue } from './metrics';
 
 export { isSessionActivityEvent, isUserInteractionEvent, isUserInteractionMetric } from './session-activity';
 

--- a/csr/csr-common/src/index.ts
+++ b/csr/csr-common/src/index.ts
@@ -6,6 +6,7 @@ export {
   IncrementalSource,
   MouseInteractions,
   type RecordingEvent,
+  type PluginEventData,
   type IncrementalSnapshotData,
   type MouseInteractionData,
   type OpaqueIncrementalData,

--- a/csr/csr-common/src/index.ts
+++ b/csr/csr-common/src/index.ts
@@ -45,7 +45,7 @@ export {
 
 export { stripUrl } from './url';
 
-export { RecordingMetricKey, type RecordingMetricKeyValue } from './metrics';
+export { RecordingMetricKey } from './metrics';
 
 export { isSessionActivityEvent, isUserInteractionEvent, isUserInteractionMetric } from './session-activity';
 

--- a/csr/csr-common/src/metrics.ts
+++ b/csr/csr-common/src/metrics.ts
@@ -13,5 +13,3 @@ export const RecordingMetricKey = {
   ConsoleError: 'consoleErrors',
   RouteChange: 'routeChanges',
 } as const;
-
-export type RecordingMetricKeyValue = (typeof RecordingMetricKey)[keyof typeof RecordingMetricKey];

--- a/csr/csr-common/src/metrics.ts
+++ b/csr/csr-common/src/metrics.ts
@@ -1,0 +1,17 @@
+export const RecordingMetricKey = {
+  Click: 'clicks',
+  Input: 'inputs',
+  RageClick: 'rageClicks',
+  DeadClick: 'deadClicks',
+  ScrollBack: 'scrollBacks',
+  TabUnfocus: 'tabUnfocuses',
+  ErrorMessage: 'errorMessages',
+  FailedNetworkRequest: 'networkRequestsFailed',
+  NetworkRequest: 'networkRequests',
+  ConsoleLog: 'consoleLogs',
+  ConsoleWarning: 'consoleWarnings',
+  ConsoleError: 'consoleErrors',
+  RouteChange: 'routeChanges',
+} as const;
+
+export type RecordingMetricKeyValue = (typeof RecordingMetricKey)[keyof typeof RecordingMetricKey];

--- a/csr/csr-common/src/session-activity.test.ts
+++ b/csr/csr-common/src/session-activity.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { IncrementalSource, RecordingEventType } from './events';
+import { IncrementalSource, RecordingCustomEventTag, RecordingEventType, RecordingPluginName } from './events';
+import { RecordingMetricKey } from './metrics';
 import { isSessionActivityEvent, isUserInteractionEvent, isUserInteractionMetric } from './session-activity';
 
 describe('session activity', () => {
@@ -14,15 +15,15 @@ describe('session activity', () => {
     },
     {
       type: RecordingEventType.Custom,
-      data: { tag: 'csr:input' },
+      data: { tag: RecordingCustomEventTag.Input },
     },
     {
       type: RecordingEventType.Plugin,
-      data: { plugin: 'csr:routeChange' },
+      data: { plugin: RecordingPluginName.RouteChange },
     },
     {
       type: RecordingEventType.Custom,
-      data: { tag: 'csr:tabUnfocus' },
+      data: { tag: RecordingCustomEventTag.TabUnfocus },
     },
   ])('identifies user interaction events', event => {
     expect(isUserInteractionEvent(event)).toBe(true);
@@ -35,7 +36,7 @@ describe('session activity', () => {
     },
     {
       type: RecordingEventType.Plugin,
-      data: { plugin: 'csr:networkRequest' },
+      data: { plugin: RecordingPluginName.NetworkRequest },
     },
     null,
     {},
@@ -50,14 +51,22 @@ describe('session activity', () => {
     expect(isSessionActivityEvent(event)).toBe(true);
   });
 
-  it.each(['clicks', 'inputs', 'rageClicks', 'deadClicks', 'scrollBacks', 'tabUnfocuses', 'routeChanges'])(
-    'identifies user interaction metrics',
+  it.each([
+    RecordingMetricKey.Click,
+    RecordingMetricKey.Input,
+    RecordingMetricKey.RageClick,
+    RecordingMetricKey.DeadClick,
+    RecordingMetricKey.ScrollBack,
+    RecordingMetricKey.TabUnfocus,
+    RecordingMetricKey.RouteChange,
+  ])('identifies user interaction metrics', metricKey => {
+    expect(isUserInteractionMetric(metricKey)).toBe(true);
+  });
+
+  it.each([RecordingMetricKey.NetworkRequest, RecordingMetricKey.ConsoleError, 'unknownMetric'])(
+    'ignores passive metrics',
     metricKey => {
-      expect(isUserInteractionMetric(metricKey)).toBe(true);
+      expect(isUserInteractionMetric(metricKey)).toBe(false);
     },
   );
-
-  it.each(['networkRequests', 'consoleErrors', 'unknownMetric'])('ignores passive metrics', metricKey => {
-    expect(isUserInteractionMetric(metricKey)).toBe(false);
-  });
 });

--- a/csr/csr-common/src/session-activity.test.ts
+++ b/csr/csr-common/src/session-activity.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { IncrementalSource, RecordingEventType } from './events';
+import { isSessionActivityEvent, isUserInteractionEvent } from './session-activity';
+
+describe('session activity', () => {
+  it.each([
+    {
+      type: RecordingEventType.IncrementalSnapshot,
+      data: { source: IncrementalSource.MouseMove },
+    },
+    {
+      type: RecordingEventType.IncrementalSnapshot,
+      data: { source: IncrementalSource.MouseInteraction },
+    },
+    {
+      type: RecordingEventType.Custom,
+      data: { tag: 'csr:input' },
+    },
+    {
+      type: RecordingEventType.Plugin,
+      data: { plugin: 'csr:routeChange' },
+    },
+  ])('identifies user interaction events', event => {
+    expect(isUserInteractionEvent(event)).toBe(true);
+  });
+
+  it.each([
+    {
+      type: RecordingEventType.IncrementalSnapshot,
+      data: { source: IncrementalSource.Mutation },
+    },
+    {
+      type: RecordingEventType.Plugin,
+      data: { plugin: 'csr:networkRequest' },
+    },
+    null,
+    {},
+  ])('ignores passive and malformed events', event => {
+    expect(isUserInteractionEvent(event)).toBe(false);
+  });
+
+  it('treats page metadata as session activity without treating it as an interaction', () => {
+    const event = { type: RecordingEventType.Meta, data: {} };
+
+    expect(isUserInteractionEvent(event)).toBe(false);
+    expect(isSessionActivityEvent(event)).toBe(true);
+  });
+});

--- a/csr/csr-common/src/session-activity.test.ts
+++ b/csr/csr-common/src/session-activity.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { IncrementalSource, RecordingEventType } from './events';
-import { isSessionActivityEvent, isUserInteractionEvent } from './session-activity';
+import { isSessionActivityEvent, isUserInteractionEvent, isUserInteractionMetric } from './session-activity';
 
 describe('session activity', () => {
   it.each([
@@ -19,6 +19,10 @@ describe('session activity', () => {
     {
       type: RecordingEventType.Plugin,
       data: { plugin: 'csr:routeChange' },
+    },
+    {
+      type: RecordingEventType.Custom,
+      data: { tag: 'csr:tabUnfocus' },
     },
   ])('identifies user interaction events', event => {
     expect(isUserInteractionEvent(event)).toBe(true);
@@ -44,5 +48,16 @@ describe('session activity', () => {
 
     expect(isUserInteractionEvent(event)).toBe(false);
     expect(isSessionActivityEvent(event)).toBe(true);
+  });
+
+  it.each(['clicks', 'inputs', 'rageClicks', 'deadClicks', 'scrollBacks', 'tabUnfocuses', 'routeChanges'])(
+    'identifies user interaction metrics',
+    metricKey => {
+      expect(isUserInteractionMetric(metricKey)).toBe(true);
+    },
+  );
+
+  it.each(['networkRequests', 'consoleErrors', 'unknownMetric'])('ignores passive metrics', metricKey => {
+    expect(isUserInteractionMetric(metricKey)).toBe(false);
   });
 });

--- a/csr/csr-common/src/session-activity.ts
+++ b/csr/csr-common/src/session-activity.ts
@@ -1,4 +1,5 @@
-import { IncrementalSource, RecordingEventType } from './events';
+import { IncrementalSource, RecordingCustomEventTag, RecordingEventType, RecordingPluginName } from './events';
+import { RecordingMetricKey } from './metrics';
 
 const USER_INTERACTION_SOURCES = new Set<number>([
   IncrementalSource.MouseMove,
@@ -18,18 +19,23 @@ type UserInteractionSignal = {
 };
 
 const USER_INTERACTION_SIGNALS: readonly UserInteractionSignal[] = [
-  { metricKey: 'clicks', tags: ['csr:click'] },
-  { metricKey: 'inputs', tags: ['csr:input'] },
-  { metricKey: 'rageClicks', tags: ['csr:rageClick'] },
-  { metricKey: 'deadClicks', tags: ['csr:deadClick'] },
-  { metricKey: 'scrollBacks', tags: ['csr:scrollBack'] },
-  { metricKey: 'tabUnfocuses', tags: ['csr:tabUnfocus'] },
+  { metricKey: RecordingMetricKey.Click, tags: [RecordingCustomEventTag.Click] },
+  { metricKey: RecordingMetricKey.Input, tags: [RecordingCustomEventTag.Input] },
+  { metricKey: RecordingMetricKey.RageClick, tags: [RecordingCustomEventTag.RageClick] },
+  { metricKey: RecordingMetricKey.DeadClick, tags: [RecordingCustomEventTag.DeadClick] },
+  { metricKey: RecordingMetricKey.ScrollBack, tags: [RecordingCustomEventTag.ScrollBack] },
   {
-    metricKey: 'routeChanges',
-    tags: ['csr:routeChange'],
-    plugins: ['csr:routeChange'],
+    metricKey: RecordingMetricKey.TabUnfocus,
+    tags: [RecordingCustomEventTag.TabUnfocus],
   },
-  { tags: ['csr:formFieldReEdit', 'csr:tabRefocus'] },
+  {
+    metricKey: RecordingMetricKey.RouteChange,
+    tags: [RecordingCustomEventTag.RouteChange],
+    plugins: [RecordingPluginName.RouteChange],
+  },
+  {
+    tags: [RecordingCustomEventTag.FormFieldReEdit, RecordingCustomEventTag.TabRefocus],
+  },
 ];
 
 const USER_INTERACTION_TAGS = new Set(USER_INTERACTION_SIGNALS.flatMap(signal => signal.tags ?? []));

--- a/csr/csr-common/src/session-activity.ts
+++ b/csr/csr-common/src/session-activity.ts
@@ -12,39 +12,29 @@ const USER_INTERACTION_SOURCES = new Set<number>([
   IncrementalSource.Selection,
 ]);
 
-type UserInteractionSignal = {
-  metricKey?: string;
-  tags?: readonly string[];
-  plugins?: readonly string[];
-};
+const USER_INTERACTION_TAGS = new Set<string>([
+  RecordingCustomEventTag.Click,
+  RecordingCustomEventTag.Input,
+  RecordingCustomEventTag.RageClick,
+  RecordingCustomEventTag.DeadClick,
+  RecordingCustomEventTag.ScrollBack,
+  RecordingCustomEventTag.TabUnfocus,
+  RecordingCustomEventTag.TabRefocus,
+  RecordingCustomEventTag.FormFieldReEdit,
+  RecordingCustomEventTag.RouteChange,
+]);
 
-const USER_INTERACTION_SIGNALS: readonly UserInteractionSignal[] = [
-  { metricKey: RecordingMetricKey.Click, tags: [RecordingCustomEventTag.Click] },
-  { metricKey: RecordingMetricKey.Input, tags: [RecordingCustomEventTag.Input] },
-  { metricKey: RecordingMetricKey.RageClick, tags: [RecordingCustomEventTag.RageClick] },
-  { metricKey: RecordingMetricKey.DeadClick, tags: [RecordingCustomEventTag.DeadClick] },
-  { metricKey: RecordingMetricKey.ScrollBack, tags: [RecordingCustomEventTag.ScrollBack] },
-  {
-    metricKey: RecordingMetricKey.TabUnfocus,
-    tags: [RecordingCustomEventTag.TabUnfocus],
-  },
-  {
-    metricKey: RecordingMetricKey.RouteChange,
-    tags: [RecordingCustomEventTag.RouteChange],
-    plugins: [RecordingPluginName.RouteChange],
-  },
-  {
-    tags: [RecordingCustomEventTag.FormFieldReEdit, RecordingCustomEventTag.TabRefocus],
-  },
-];
+const USER_INTERACTION_PLUGINS = new Set<string>([RecordingPluginName.RouteChange]);
 
-const USER_INTERACTION_TAGS = new Set(USER_INTERACTION_SIGNALS.flatMap(signal => signal.tags ?? []));
-
-const USER_INTERACTION_PLUGINS = new Set(USER_INTERACTION_SIGNALS.flatMap(signal => signal.plugins ?? []));
-
-const USER_INTERACTION_METRIC_KEYS = new Set(
-  USER_INTERACTION_SIGNALS.flatMap(signal => (signal.metricKey ? [signal.metricKey] : [])),
-);
+const USER_INTERACTION_METRIC_KEYS = new Set<string>([
+  RecordingMetricKey.Click,
+  RecordingMetricKey.Input,
+  RecordingMetricKey.RageClick,
+  RecordingMetricKey.DeadClick,
+  RecordingMetricKey.ScrollBack,
+  RecordingMetricKey.TabUnfocus,
+  RecordingMetricKey.RouteChange,
+]);
 
 const isObject = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
 

--- a/csr/csr-common/src/session-activity.ts
+++ b/csr/csr-common/src/session-activity.ts
@@ -11,16 +11,34 @@ const USER_INTERACTION_SOURCES = new Set<number>([
   IncrementalSource.Selection,
 ]);
 
-const USER_INTERACTION_TAGS = new Set([
-  'csr:click',
-  'csr:deadClick',
-  'csr:rageClick',
-  'csr:input',
-  'csr:formFieldReEdit',
-  'csr:scrollBack',
-  'csr:routeChange',
-  'csr:tabRefocus',
-]);
+type UserInteractionSignal = {
+  metricKey?: string;
+  tags?: readonly string[];
+  plugins?: readonly string[];
+};
+
+const USER_INTERACTION_SIGNALS: readonly UserInteractionSignal[] = [
+  { metricKey: 'clicks', tags: ['csr:click'] },
+  { metricKey: 'inputs', tags: ['csr:input'] },
+  { metricKey: 'rageClicks', tags: ['csr:rageClick'] },
+  { metricKey: 'deadClicks', tags: ['csr:deadClick'] },
+  { metricKey: 'scrollBacks', tags: ['csr:scrollBack'] },
+  { metricKey: 'tabUnfocuses', tags: ['csr:tabUnfocus'] },
+  {
+    metricKey: 'routeChanges',
+    tags: ['csr:routeChange'],
+    plugins: ['csr:routeChange'],
+  },
+  { tags: ['csr:formFieldReEdit', 'csr:tabRefocus'] },
+];
+
+const USER_INTERACTION_TAGS = new Set(USER_INTERACTION_SIGNALS.flatMap(signal => signal.tags ?? []));
+
+const USER_INTERACTION_PLUGINS = new Set(USER_INTERACTION_SIGNALS.flatMap(signal => signal.plugins ?? []));
+
+const USER_INTERACTION_METRIC_KEYS = new Set(
+  USER_INTERACTION_SIGNALS.flatMap(signal => (signal.metricKey ? [signal.metricKey] : [])),
+);
 
 const isObject = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
 
@@ -37,8 +55,14 @@ export const isUserInteractionEvent = (event: unknown): boolean => {
     return typeof event.data.tag === 'string' && USER_INTERACTION_TAGS.has(event.data.tag);
   }
 
-  return event.type === RecordingEventType.Plugin && event.data.plugin === 'csr:routeChange';
+  return (
+    event.type === RecordingEventType.Plugin &&
+    typeof event.data.plugin === 'string' &&
+    USER_INTERACTION_PLUGINS.has(event.data.plugin)
+  );
 };
+
+export const isUserInteractionMetric = (metricKey: string): boolean => USER_INTERACTION_METRIC_KEYS.has(metricKey);
 
 export const isSessionActivityEvent = (event: unknown): boolean =>
   (isObject(event) && event.type === RecordingEventType.Meta) || isUserInteractionEvent(event);

--- a/csr/csr-common/src/session-activity.ts
+++ b/csr/csr-common/src/session-activity.ts
@@ -1,0 +1,44 @@
+import { IncrementalSource, RecordingEventType } from './events';
+
+const USER_INTERACTION_SOURCES = new Set<number>([
+  IncrementalSource.MouseMove,
+  IncrementalSource.MouseInteraction,
+  IncrementalSource.Scroll,
+  IncrementalSource.Input,
+  IncrementalSource.TouchMove,
+  IncrementalSource.MediaInteraction,
+  IncrementalSource.Drag,
+  IncrementalSource.Selection,
+]);
+
+const USER_INTERACTION_TAGS = new Set([
+  'csr:click',
+  'csr:deadClick',
+  'csr:rageClick',
+  'csr:input',
+  'csr:formFieldReEdit',
+  'csr:scrollBack',
+  'csr:routeChange',
+  'csr:tabRefocus',
+]);
+
+const isObject = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
+
+export const isUserInteractionEvent = (event: unknown): boolean => {
+  if (!isObject(event) || !isObject(event.data)) {
+    return false;
+  }
+
+  if (event.type === RecordingEventType.IncrementalSnapshot) {
+    return typeof event.data.source === 'number' && USER_INTERACTION_SOURCES.has(event.data.source);
+  }
+
+  if (event.type === RecordingEventType.Custom) {
+    return typeof event.data.tag === 'string' && USER_INTERACTION_TAGS.has(event.data.tag);
+  }
+
+  return event.type === RecordingEventType.Plugin && event.data.plugin === 'csr:routeChange';
+};
+
+export const isSessionActivityEvent = (event: unknown): boolean =>
+  (isObject(event) && event.type === RecordingEventType.Meta) || isUserInteractionEvent(event);

--- a/csr/csr-common/src/uploader/create-uploader.test.ts
+++ b/csr/csr-common/src/uploader/create-uploader.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { IncrementalSource, RecordingEventType } from '../events';
+import { IncrementalSource, RecordingEventType, RecordingPluginName } from '../events';
 import type { CreateUploaderOptions } from './types';
 
 vi.mock('./worker/worker-script', () => ({
@@ -90,6 +90,7 @@ describe('createUploader', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
     blobUrls.length = 0;
     delete (globalThis as Record<string, unknown>).SharedWorker;
     delete (globalThis as Record<string, unknown>).window;
@@ -330,61 +331,71 @@ describe('createUploader', () => {
 
   it('marks active and passive frames for the backend inactivity timeout', async () => {
     const messages: unknown[] = [];
-    (globalThis as Record<string, unknown>).window = {
+    vi.stubGlobal('window', {
       addEventListener() {},
       devicePixelRatio: 1,
       innerHeight: 800,
       innerWidth: 1200,
       location: { origin: 'https://example.com', pathname: '/' },
       screen: { height: 800, width: 1200 },
-    };
-    (globalThis as Record<string, unknown>).document = {
+    });
+    vi.stubGlobal('document', {
       addEventListener() {},
       referrer: '',
       visibilityState: 'visible',
-    };
-    (globalThis as Record<string, unknown>).navigator = {
+    });
+    vi.stubGlobal('navigator', {
       language: 'en',
       userAgent: 'test',
-    };
-    (globalThis as Record<string, unknown>).Worker = class {
-      onerror: ((event: Event) => void) | null = null;
-      onmessage: ((event: MessageEvent) => void) | null = null;
+    });
+    vi.stubGlobal(
+      'Worker',
+      class {
+        onerror: ((event: Event) => void) | null = null;
+        onmessage: ((event: MessageEvent) => void) | null = null;
 
-      postMessage(message: unknown) {
-        messages.push(message);
-        if ((message as { type?: string }).type === 'hello') {
-          queueMicrotask(() =>
-            this.onmessage?.(
-              new MessageEvent('message', {
-                data: {
-                  type: 'welcome',
-                  result: { sessionId: 'sessions/test', sessionToken: 'token' },
-                },
-              }),
-            ),
-          );
+        postMessage(message: unknown) {
+          messages.push(message);
+          if (typeof message === 'object' && message !== null && 'type' in message && message.type === 'hello') {
+            queueMicrotask(() =>
+              this.onmessage?.(
+                new MessageEvent('message', {
+                  data: {
+                    type: 'welcome',
+                    result: { sessionId: 'sessions/test', sessionToken: 'token' },
+                  },
+                }),
+              ),
+            );
+          }
         }
-      }
-    };
-    delete (globalThis as Record<string, unknown>).SharedWorker;
+      },
+    );
+    vi.stubGlobal('SharedWorker', undefined);
 
     const createUploader = await loadCreateUploader();
     const uploader = await createUploader({ ...DEFAULTS, workerMode: 'dedicated' });
 
     uploader?.({
       type: RecordingEventType.Plugin,
-      data: { plugin: 'csr:networkRequest' },
+      data: { plugin: RecordingPluginName.NetworkRequest },
     });
     uploader?.({
       type: RecordingEventType.IncrementalSnapshot,
       data: { source: IncrementalSource.MouseInteraction },
     });
 
-    const frames = messages.filter(
-      (message): message is { type: 'frame'; frame: { userActivity: boolean } } =>
-        (message as { type?: string }).type === 'frame',
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'frame',
+          frame: expect.objectContaining({ userActivity: false }),
+        }),
+        expect.objectContaining({
+          type: 'frame',
+          frame: expect.objectContaining({ userActivity: true }),
+        }),
+      ]),
     );
-    expect(frames.map(message => message.frame.userActivity)).toEqual([false, true]);
   });
 });

--- a/csr/csr-common/src/uploader/create-uploader.test.ts
+++ b/csr/csr-common/src/uploader/create-uploader.test.ts
@@ -93,9 +93,6 @@ describe('createUploader', () => {
     vi.unstubAllGlobals();
     blobUrls.length = 0;
     delete (globalThis as Record<string, unknown>).SharedWorker;
-    delete (globalThis as Record<string, unknown>).window;
-    delete (globalThis as Record<string, unknown>).document;
-    delete (globalThis as Record<string, unknown>).navigator;
   });
 
   async function loadCreateUploader() {

--- a/csr/csr-common/src/uploader/create-uploader.test.ts
+++ b/csr/csr-common/src/uploader/create-uploader.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IncrementalSource, RecordingEventType } from '../events';
 import type { CreateUploaderOptions } from './types';
 
 vi.mock('./worker/worker-script', () => ({
@@ -91,6 +92,9 @@ describe('createUploader', () => {
     vi.restoreAllMocks();
     blobUrls.length = 0;
     delete (globalThis as Record<string, unknown>).SharedWorker;
+    delete (globalThis as Record<string, unknown>).window;
+    delete (globalThis as Record<string, unknown>).document;
+    delete (globalThis as Record<string, unknown>).navigator;
   });
 
   async function loadCreateUploader() {
@@ -322,5 +326,65 @@ describe('createUploader', () => {
         /welcome timeout/,
       );
     });
+  });
+
+  it('marks active and passive frames for the backend inactivity timeout', async () => {
+    const messages: unknown[] = [];
+    (globalThis as Record<string, unknown>).window = {
+      addEventListener() {},
+      devicePixelRatio: 1,
+      innerHeight: 800,
+      innerWidth: 1200,
+      location: { origin: 'https://example.com', pathname: '/' },
+      screen: { height: 800, width: 1200 },
+    };
+    (globalThis as Record<string, unknown>).document = {
+      addEventListener() {},
+      referrer: '',
+      visibilityState: 'visible',
+    };
+    (globalThis as Record<string, unknown>).navigator = {
+      language: 'en',
+      userAgent: 'test',
+    };
+    (globalThis as Record<string, unknown>).Worker = class {
+      onerror: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+
+      postMessage(message: unknown) {
+        messages.push(message);
+        if ((message as { type?: string }).type === 'hello') {
+          queueMicrotask(() =>
+            this.onmessage?.(
+              new MessageEvent('message', {
+                data: {
+                  type: 'welcome',
+                  result: { sessionId: 'sessions/test', sessionToken: 'token' },
+                },
+              }),
+            ),
+          );
+        }
+      }
+    };
+    delete (globalThis as Record<string, unknown>).SharedWorker;
+
+    const createUploader = await loadCreateUploader();
+    const uploader = await createUploader({ ...DEFAULTS, workerMode: 'dedicated' });
+
+    uploader?.({
+      type: RecordingEventType.Plugin,
+      data: { plugin: 'csr:networkRequest' },
+    });
+    uploader?.({
+      type: RecordingEventType.IncrementalSnapshot,
+      data: { source: IncrementalSource.MouseInteraction },
+    });
+
+    const frames = messages.filter(
+      (message): message is { type: 'frame'; frame: { userActivity: boolean } } =>
+        (message as { type?: string }).type === 'frame',
+    );
+    expect(frames.map(message => message.frame.userActivity)).toEqual([false, true]);
   });
 });

--- a/csr/csr-common/src/uploader/create-uploader.ts
+++ b/csr/csr-common/src/uploader/create-uploader.ts
@@ -1,5 +1,6 @@
 import type { CreateUploaderOptions, Frame, Uploader } from './types';
 import { ClientContext, collectUserAgentContext } from './client-context';
+import { isSessionActivityEvent } from '../session-activity';
 import { workerScript } from './worker/worker-script';
 
 const STORAGE_TAB_ID = 'csr:tabId';
@@ -213,6 +214,7 @@ export async function createUploader(opts: CreateUploaderOptions): Promise<Uploa
       tabId: effectiveTabId,
       eventCounter: counter,
       data: event,
+      userActivity: isSessionActivityEvent(event),
       ...(nextAdoptionMeta ?? {}),
     };
     counter += 1;

--- a/csr/csr-common/src/uploader/types.ts
+++ b/csr/csr-common/src/uploader/types.ts
@@ -94,6 +94,8 @@ export interface Frame {
   eventCounter: number;
   /** Opaque payload from the recorder. */
   data: unknown;
+  /** Whether the frame should refresh the backend's session inactivity timeout. */
+  userActivity?: boolean;
   /** Set only on the first frame emitted after the tab was adopted into a different session. */
   adoptedFromSessionId?: string;
   /** Epoch millis of the adoption event. */

--- a/csr/csr-recorder/src/engine/rrweb-engine.test.ts
+++ b/csr/csr-recorder/src/engine/rrweb-engine.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RecordingPluginName } from '@spotify-confidence/csr-common';
 import { RrwebEngine } from './rrweb-engine';
 
 const recordSpy = vi.fn().mockReturnValue(() => {});
@@ -61,7 +62,7 @@ describe('RrwebEngine', () => {
   it('rebuilds blocked elements as labelled inert placeholders', () => {
     new RrwebEngine().start({}, () => {});
     const plugin = recordSpy.mock.calls[0][0].plugins.find(
-      ({ name }: { name: string }) => name === 'csr/blocked-element-labels@1',
+      ({ name }: { name: string }) => name === RecordingPluginName.BlockedElementLabels,
     );
     const event = {
       type: 2,
@@ -120,7 +121,9 @@ describe('RrwebEngine', () => {
 
   it('records copy, cut, and paste actions without reading clipboard contents', () => {
     new RrwebEngine().start({}, () => {});
-    const plugin = recordSpy.mock.calls[0][0].plugins.find(({ name }: { name: string }) => name === 'csr/clipboard@1');
+    const plugin = recordSpy.mock.calls[0][0].plugins.find(
+      ({ name }: { name: string }) => name === RecordingPluginName.Clipboard,
+    );
     const getId = vi.fn().mockReturnValue(42);
     plugin.getMirror({ nodeMirror: { getId } });
     const callback = vi.fn();
@@ -154,7 +157,7 @@ describe('RrwebEngine', () => {
   it('keeps native click modifiers through a browser microtask checkpoint', async () => {
     new RrwebEngine().start({}, () => {});
     const plugin = recordSpy.mock.calls[0][0].plugins.find(
-      ({ name }: { name: string }) => name === 'csr/click-modifiers@1',
+      ({ name }: { name: string }) => name === RecordingPluginName.ClickModifiers,
     );
     const removeObserver = plugin.observer(() => {}, window);
 
@@ -200,7 +203,7 @@ describe('RrwebEngine', () => {
   it('does not add stale modifiers to a later click', async () => {
     new RrwebEngine().start({}, () => {});
     const plugin = recordSpy.mock.calls[0][0].plugins.find(
-      ({ name }: { name: string }) => name === 'csr/click-modifiers@1',
+      ({ name }: { name: string }) => name === RecordingPluginName.ClickModifiers,
     );
     const removeObserver = plugin.observer(() => {}, window);
     document.dispatchEvent(new MouseEvent('click', { metaKey: true }));

--- a/csr/csr-recorder/src/engine/rrweb-engine.ts
+++ b/csr/csr-recorder/src/engine/rrweb-engine.ts
@@ -1,4 +1,4 @@
-import { type ConsoleLogLevel, type RecordingEvent } from '@spotify-confidence/csr-common';
+import { RecordingPluginName, type ConsoleLogLevel, type RecordingEvent } from '@spotify-confidence/csr-common';
 import { RecordingConfig, DEFAULT_MASK_SELECTORS, DEFAULT_BLOCK_SELECTORS } from '../types';
 import { RecordingEngine } from './index';
 import { EventType, IncrementalSource, MouseInteractions, record, takeFullSnapshot, type recordOptions } from 'rrweb';
@@ -42,7 +42,7 @@ function labelBlockedElement(node: SerializedNode): void {
  */
 function blockedElementLabelsPlugin(): RrwebPlugin {
   return {
-    name: 'csr/blocked-element-labels@1',
+    name: RecordingPluginName.BlockedElementLabels,
     options: {},
     observer: () => () => {},
     eventProcessor: event => {
@@ -68,7 +68,7 @@ function clipboardActionsPlugin(): RrwebPlugin {
   let getId: ((node: Node) => number) | undefined;
 
   return {
-    name: 'csr/clipboard@1',
+    name: RecordingPluginName.Clipboard,
     options: {},
     getMirror: ({ nodeMirror }) => {
       getId = node => nodeMirror.getId(node);
@@ -99,7 +99,7 @@ function clickModifiersPlugin(): RrwebPlugin {
   let pendingClick: ClickModifiers | null = null;
 
   return {
-    name: 'csr/click-modifiers@1',
+    name: RecordingPluginName.ClickModifiers,
     options: {},
     observer: (_callback, win) => {
       const onClick = (event: Event) => {

--- a/csr/csr-recorder/src/recorder-routing.test.ts
+++ b/csr/csr-recorder/src/recorder-routing.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { RecordingEvent, RecordingEventType, type RouteChangePluginData } from '@spotify-confidence/csr-common';
+import { RecordingEvent, RecordingEventType, RecordingPluginName } from '@spotify-confidence/csr-common';
 import { Recorder } from './recorder';
 import { RecordingEngine } from './engine';
 
@@ -32,10 +32,11 @@ class MockEngine implements RecordingEngine {
 }
 
 function routeChangeEvents(onEvent: ReturnType<typeof vi.fn>) {
-  return (onEvent.mock.calls as [RecordingEvent][])
-    .map(([e]) => e)
-    .filter(e => e.type === RecordingEventType.Plugin && (e.data as RouteChangePluginData).plugin === 'csr:routeChange')
-    .map(e => (e.data as RouteChangePluginData).payload);
+  return onEvent.mock.calls.flatMap(([event]: [RecordingEvent]) =>
+    event.type === RecordingEventType.Plugin && event.data.plugin === RecordingPluginName.RouteChange
+      ? [event.data.payload]
+      : [],
+  );
 }
 
 describe('Recorder route change capture', () => {

--- a/csr/csr-recorder/src/recorder.test.ts
+++ b/csr/csr-recorder/src/recorder.test.ts
@@ -1,8 +1,15 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { RecordingEvent, RecordingEventType, type NetworkRequestPluginData } from '@spotify-confidence/csr-common';
+import { RecordingEvent, RecordingEventType, RecordingPluginName } from '@spotify-confidence/csr-common';
 import { Recorder } from './recorder';
 import { RecordingEngine } from './engine';
 import { RecorderState } from './types';
+
+const networkRequestEvents = (onEvent: ReturnType<typeof vi.fn>) =>
+  onEvent.mock.calls.flatMap(([event]: [RecordingEvent]) =>
+    event.type === RecordingEventType.Plugin && event.data.plugin === RecordingPluginName.NetworkRequest
+      ? [event.data]
+      : [],
+  );
 
 function makeEvent(timestamp: number): RecordingEvent {
   return { type: RecordingEventType.Meta, timestamp, data: {} };
@@ -130,12 +137,10 @@ describe('Recorder network request capture', () => {
 
     await globalThis.fetch('https://api.example.com/data');
 
-    const pluginEvents = onEvent.mock.calls
-      .map(([e]: [RecordingEvent]) => e)
-      .filter(e => e.type === RecordingEventType.Plugin);
-    expect(pluginEvents).toHaveLength(1);
-    const data = pluginEvents[0].data as NetworkRequestPluginData;
-    expect(data.plugin).toBe('csr:networkRequest');
+    const events = networkRequestEvents(onEvent);
+    expect(events).toHaveLength(1);
+    const data = events[0];
+    expect(data.plugin).toBe(RecordingPluginName.NetworkRequest);
     expect(data.payload.initiator).toBe('fetch');
     expect(data.payload.method).toBe('GET');
     expect(data.payload.url).toBe('https://api.example.com/data');
@@ -156,11 +161,9 @@ describe('Recorder network request capture', () => {
 
     await globalThis.fetch('https://api.example.com/data').catch(() => {});
 
-    const pluginEvents = onEvent.mock.calls
-      .map(([e]: [RecordingEvent]) => e)
-      .filter(e => e.type === RecordingEventType.Plugin);
-    expect(pluginEvents).toHaveLength(1);
-    const data = pluginEvents[0].data as NetworkRequestPluginData;
+    const events = networkRequestEvents(onEvent);
+    expect(events).toHaveLength(1);
+    const data = events[0];
     expect(data.payload.status).toBe(0);
 
     recorder.stop();
@@ -177,10 +180,7 @@ describe('Recorder network request capture', () => {
 
     await globalThis.fetch('https://api.example.com/data', { method: 'post' });
 
-    const pluginEvents = onEvent.mock.calls
-      .map(([e]: [RecordingEvent]) => e)
-      .filter(e => e.type === RecordingEventType.Plugin);
-    const data = pluginEvents[0].data as NetworkRequestPluginData;
+    const data = networkRequestEvents(onEvent)[0];
     expect(data.payload.method).toBe('POST');
 
     recorder.stop();
@@ -197,10 +197,7 @@ describe('Recorder network request capture', () => {
 
     await globalThis.fetch(new Request('https://api.example.com/data', { method: 'DELETE' }));
 
-    const pluginEvents = onEvent.mock.calls
-      .map(([e]: [RecordingEvent]) => e)
-      .filter(e => e.type === RecordingEventType.Plugin);
-    const data = pluginEvents[0].data as NetworkRequestPluginData;
+    const data = networkRequestEvents(onEvent)[0];
     expect(data.payload.method).toBe('DELETE');
     expect(data.payload.url).toBe('https://api.example.com/data');
 
@@ -228,7 +225,7 @@ describe('Recorder network request capture', () => {
       }),
     });
 
-    const data = onEvent.mock.calls[0][0].data as NetworkRequestPluginData;
+    const data = networkRequestEvents(onEvent)[0];
     expect(data.payload.graphql).toEqual({ operationName: 'GetUser' });
     expect(JSON.stringify(data.payload)).not.toContain('private-user-id');
 

--- a/csr/csr-recorder/src/recorder.ts
+++ b/csr/csr-recorder/src/recorder.ts
@@ -1,6 +1,7 @@
 import {
   RecordingEvent,
   RecordingEventType,
+  RecordingPluginName,
   type TabVisibilityPluginData,
   type NetworkRequestPluginData,
   type RouteChangePluginData,
@@ -54,7 +55,7 @@ export class Recorder {
     if (typeof document !== 'undefined') {
       this.visibilityHandler = () => {
         const data: TabVisibilityPluginData = {
-          plugin: 'csr:tabVisibility',
+          plugin: RecordingPluginName.TabVisibility,
           payload: { hidden: document.hidden },
         };
         this.onEvent({
@@ -86,7 +87,7 @@ export class Recorder {
 
   private emitNetworkRequest(payload: NetworkRequestPluginData['payload']): void {
     const data: NetworkRequestPluginData = {
-      plugin: 'csr:networkRequest',
+      plugin: RecordingPluginName.NetworkRequest,
       payload,
     };
     this.onEvent({
@@ -216,7 +217,7 @@ export class Recorder {
     const paramTo = this.parameterizeRoute(to);
     if (paramFrom === paramTo) return;
     const data: RouteChangePluginData = {
-      plugin: 'csr:routeChange',
+      plugin: RecordingPluginName.RouteChange,
       payload: { from: paramFrom, to: paramTo, trigger },
     };
     this.onEvent({

--- a/csr/session-recording/src/index.ts
+++ b/csr/session-recording/src/index.ts
@@ -2,6 +2,7 @@ import { record } from '@spotify-confidence/csr-recorder';
 import type { ConsoleLogLevel } from '@spotify-confidence/csr-common';
 import {
   RecordingEventType,
+  RecordingPluginName,
   type TagPluginData,
   type MeasurePluginData,
   type FlagEvaluationPluginData,
@@ -175,7 +176,7 @@ export function initSessionRecorder(options: InitSessionRecorderOptions): Sessio
 
       stopObservingFlags = observeFlags(({ flagKey, variant, assignmentOrigin }) => {
         const data: FlagEvaluationPluginData = {
-          plugin: 'csr:flagEvaluation',
+          plugin: RecordingPluginName.FlagEvaluation,
           payload: { flagKey, variant, assignmentOrigin },
         };
         sendEvent?.({
@@ -225,7 +226,7 @@ export function initSessionRecorder(options: InitSessionRecorderOptions): Sessio
         return;
       }
       const data: TagPluginData = {
-        plugin: 'csr:tag',
+        plugin: RecordingPluginName.Tag,
         payload: value !== undefined ? { key, value } : { key },
       };
       sendEvent?.({
@@ -246,7 +247,7 @@ export function initSessionRecorder(options: InitSessionRecorderOptions): Sessio
         return;
       }
       const data: MeasurePluginData = {
-        plugin: 'csr:measure',
+        plugin: RecordingPluginName.Measure,
         payload: value !== undefined ? { key, value } : { key },
       };
       sendEvent?.({


### PR DESCRIPTION
## Summary

- mark recording frames according to whether they represent session activity
- keep passive network and console events from refreshing the backend inactivity timeout
- centralize recording event, plugin, and metric identifiers shared by the recorder and UI

## Testing

- `yarn test:csr`
- `yarn lint:csr`
- `yarn tsc --noEmit -p csr/csr-common/tsconfig.json`
- `yarn tsc --noEmit -p csr/csr-recorder/tsconfig.json`
- `yarn tsc --noEmit -p csr/session-recording/tsconfig.json`