### PR TITLE
fix: strip query and hash from recording URLs

### DIFF
--- a/csr/csr-common/src/index.ts
+++ b/csr/csr-common/src/index.ts
@@ -43,7 +43,7 @@ export {
   type FlagEvaluationPluginData,
 } from './events';
 
-export { stripUrl } from './url';
+export { stripUrl, stripUrlQueryAndHash } from './url';
 
 export { RecordingMetricKey } from './metrics';
 

--- a/csr/csr-common/src/uploader/client-context.test.ts
+++ b/csr/csr-common/src/uploader/client-context.test.ts
@@ -84,6 +84,33 @@ describe('collectUserAgentContext', () => {
     });
   });
 
+  it.each([
+    ['https://referrer.example/path?email=alice@example.com#token', 'https://referrer.example/path'],
+    ['https://referrer.example/path#token?email=alice@example.com', 'https://referrer.example/path'],
+    ['https://referrer.example/path?email=alice@example.com', 'https://referrer.example/path'],
+    ['https://referrer.example/path#token', 'https://referrer.example/path'],
+    ['', ''],
+    ['invalid-url?email=alice@example.com#token', 'invalid-url'],
+  ])('strips query/hash from referrer %s', (referrer, expected) => {
+    stubBrowser({ document: { referrer } });
+    expect(collectUserAgentContext()?.referrer).toBe(expected);
+  });
+
+  it('excludes query/hash from the initial document URI', () => {
+    stubBrowser({
+      window: {
+        location: {
+          origin: 'https://example.com',
+          pathname: '/path',
+          search: '?email=alice@example.com',
+          hash: '#token',
+          href: 'https://example.com/path?email=alice@example.com#token',
+        },
+      },
+    });
+    expect(collectUserAgentContext()?.uri).toBe('https://example.com/path');
+  });
+
   it('flags `mobile` platform type as mobile=true', () => {
     parse.mockReturnValueOnce({
       os: {},

--- a/csr/csr-common/src/uploader/client-context.ts
+++ b/csr/csr-common/src/uploader/client-context.ts
@@ -1,4 +1,5 @@
 import Bowser from 'bowser';
+import { stripUrlQueryAndHash } from '../url';
 
 /**
  * JSON-shaped values accepted in a Context — matches `google.protobuf.Struct`.
@@ -31,6 +32,7 @@ export type UserAgentContext = {
   devicePixelRatio?: number;
   /** Initial document URI — without query/hash to avoid leaking PII. */
   uri?: string;
+  /** Document referrer — without query/hash to avoid leaking PII. */
   referrer?: string;
 };
 
@@ -65,6 +67,6 @@ export function collectUserAgentContext(): UserAgentContext | undefined {
     screenHeight: window.screen.height,
     devicePixelRatio: window.devicePixelRatio,
     uri: `${window.location.origin}${window.location.pathname}`,
-    referrer: document.referrer,
+    referrer: stripUrlQueryAndHash(document.referrer),
   };
 }

--- a/csr/csr-common/src/url.ts
+++ b/csr/csr-common/src/url.ts
@@ -1,3 +1,8 @@
+/** Remove query strings and fragments, including from relative or malformed URLs. */
+export function stripUrlQueryAndHash(url: string): string {
+  return url.split(/[?#]/, 1)[0];
+}
+
 /**
  * Extract only the pathname from a URL, stripping origin, query string, and
  * hash. Used across recorder and analyzer to avoid capturing PII in route data.

--- a/csr/csr-recorder/README.md
+++ b/csr/csr-recorder/README.md
@@ -53,7 +53,7 @@ const stop = record(event => {}, {
 });
 ```
 
-The same parameterization is also applied to the `href` in rrweb Meta events.
+The same parameterization is also applied to the `href` in rrweb Meta events. Query strings and fragments are removed from Meta event URLs and the session's document referrer before recording.
 
 ## rrweb version
 

--- a/csr/csr-recorder/src/recorder-routing.test.ts
+++ b/csr/csr-recorder/src/recorder-routing.test.ts
@@ -234,20 +234,58 @@ describe('Recorder route change capture', () => {
     recorder.stop();
   });
 
+  it.each([
+    ['https://example.com/users/123?email=alice@example.com#token', 'https://example.com/users/:id'],
+    ['https://example.com/users/123#token?email=alice@example.com', 'https://example.com/users/:id'],
+    ['https://example.com/users/123?email=alice@example.com', 'https://example.com/users/:id'],
+    ['https://example.com/users/123#token', 'https://example.com/users/:id'],
+    ['/users/123?email=alice@example.com#token', '/users/:id'],
+    ['invalid-url?email=alice@example.com#token', 'invalid-url'],
+    ['', ''],
+  ])('strips query/hash from Meta href %s even with route capture disabled', (href, expected) => {
+    const engine = new MockEngine();
+    const event: RecordingEvent = {
+      type: RecordingEventType.Meta,
+      timestamp: 1,
+      data: { href, width: 1920, height: 1080 },
+    };
+    engine.eventsOnStart = [event];
+    const onEvent = vi.fn();
+    const recorder = new Recorder({ engine, onEvent });
+    recorder.start({ captureRouteChanges: false });
+    // Later snapshots must be sanitized too.
+    engine.emit(event);
+
+    expect(onEvent).toHaveBeenCalledTimes(2);
+    for (const [recorded] of onEvent.mock.calls) {
+      expect(recorded).toEqual({ ...event, data: { ...event.data, href: expected } });
+    }
+    expect(event.data).toEqual({ href, width: 1920, height: 1080 });
+
+    recorder.stop();
+  });
+
   it('parameterizes meta href using custom parameterizeRoute', () => {
     const engine = new MockEngine();
     engine.eventsOnStart = [
       {
         type: RecordingEventType.Meta,
         timestamp: 1,
-        data: { href: 'https://example.com/teams/acme-corp/dashboard', width: 1920, height: 1080 },
+        data: {
+          href: 'https://example.com/teams/acme-corp/dashboard?email=alice@example.com#token',
+          width: 1920,
+          height: 1080,
+        },
       },
     ];
     const onEvent = vi.fn();
     const recorder = new Recorder({ engine, onEvent });
+    const parameterizeRoute = vi.fn((route: string) => route.replace(/\/teams\/[^/]+/, '/teams/:slug'));
     recorder.start({
-      parameterizeRoute: route => route.replace(/\/teams\/[^/]+/, '/teams/:slug'),
+      parameterizeRoute,
     });
+
+    expect(parameterizeRoute).toHaveBeenCalledWith('/teams/acme-corp/dashboard');
 
     const metaEvents = (onEvent.mock.calls as [RecordingEvent][])
       .map(([e]) => e)

--- a/csr/csr-recorder/src/recorder.ts
+++ b/csr/csr-recorder/src/recorder.ts
@@ -2,6 +2,7 @@ import {
   RecordingEvent,
   RecordingEventType,
   RecordingPluginName,
+  stripUrlQueryAndHash,
   type TabVisibilityPluginData,
   type NetworkRequestPluginData,
   type RouteChangePluginData,
@@ -202,12 +203,13 @@ export class Recorder {
   }
 
   private parameterizeHref(href: string): string {
+    const strippedHref = stripUrlQueryAndHash(href);
     try {
-      const url = new URL(href);
+      const url = new URL(strippedHref);
       url.pathname = this.parameterizeRoute(url.pathname);
       return url.toString();
     } catch (_e) {
-      return this.parameterizeRoute(href);
+      return this.parameterizeRoute(strippedHref);
     }
   }
 


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

rrweb Meta events and the session referrer could retain query parameters and fragments containing private data. Strip both before recording while preserving route parameterization, including for relative or malformed URLs.

Validation: all 184 CSR tests pass; csr-common and csr-recorder typechecks, changed-file lint, and formatting checks pass.

#### :heavy_check_mark: Checklist

- [x] All tests are passing
- [x] Relevant documentation updated
- [x] linter/style run on changed files
- [ ] Tests added for new functionality
- [x] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app
