### PR TITLE
chore: remove codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @Billlynch @andreas-karlsson @fabriziodemaria @mfranberg @vahidlazio @nicklasl @spotify/confidence-sdk-maintainers @sam-cook @AHB @umberto-sonnino

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ We adhere to the [conventional commits](https://www.conventionalcommits.org/en/v
 
 ## Code Review
 
-Pull requests raised will be reviewed by a code owner and will be merged when all comments are resolved and the
+Pull requests raised will be reviewed by a maintainer and will be merged when all comments are resolved and the
 workflows complete successfully.
 
 ## Documentation


### PR DESCRIPTION
## Summary

- remove the catch-all CODEOWNERS file
- refer to maintainer review in the contributing guide

## Validation

- git diff --check
- formatting not run because dependencies are not installed (documentation-only change)

## Rollout

Disable Require review from Code Owners in the active main branch ruleset when this merges.